### PR TITLE
fix(listings): batch celebration CTA + once-per-batch behavior

### DIFF
--- a/e2e/015-listings-creation/015-listings-creation.spec.ts
+++ b/e2e/015-listings-creation/015-listings-creation.spec.ts
@@ -572,13 +572,15 @@ test.describe("Listings Creation Flow", () => {
     await approveBtn.click({ force: true });
 
     // 10. Verify Completion & Navigation
-    // Expect Celebration & Return Button
-    const returnBtn = page.getByRole("button", { name: "Return to Dashboard" });
+    // Expect Celebration & Shopify Products CTA
+    const returnBtn = page.getByRole("button", {
+      name: "Go to Shopify Products",
+    });
     await expect(returnBtn).toBeVisible({ timeout: 10000 });
     await returnBtn.click();
 
-    // Should be on Dashboard
-    await expect(page).toHaveURL(/\/$/);
+    // Should be on Shopify products
+    await expect(page).toHaveURL(/\/shopify-products$/);
 
     docHelper.writeReadme();
   });

--- a/src/lib/listing-creation-slice.ts
+++ b/src/lib/listing-creation-slice.ts
@@ -796,12 +796,14 @@ const listingCreationSlice = createSlice({
       console.log("[Slice] Completing Batch. Active ID:", state.activeBatchId);
       if (state.activeBatchId) {
         state.lastCompletedBatchId = state.activeBatchId;
+        // Reset celebration gate only when a real active batch transitions to completed.
+        // This prevents duplicate/replayed complete_batch actions from retriggering confetti.
+        state.hasCelebrated = false;
       }
       state.activeBatchJans = [];
       state.currentStepIndex = 0;
       state.activeBatchId = undefined;
       state.activeBatchCreatedAt = undefined;
-      state.hasCelebrated = false;
     },
     mark_celebrated: (state) => {
       state.hasCelebrated = true;

--- a/src/lib/listing-creation-slice.ts
+++ b/src/lib/listing-creation-slice.ts
@@ -796,9 +796,6 @@ const listingCreationSlice = createSlice({
       console.log("[Slice] Completing Batch. Active ID:", state.activeBatchId);
       if (state.activeBatchId) {
         state.lastCompletedBatchId = state.activeBatchId;
-        // Reset celebration gate only when a real active batch transitions to completed.
-        // This prevents duplicate/replayed complete_batch actions from retriggering confetti.
-        state.hasCelebrated = false;
       }
       state.activeBatchJans = [];
       state.currentStepIndex = 0;

--- a/src/routes/listings/create/+page.svelte
+++ b/src/routes/listings/create/+page.svelte
@@ -12,7 +12,6 @@
     set_current_step,
     recalculate_batch_navigation,
     set_proposal_handle_thunk,
-    clear_celebration,
     mark_celebrated,
     set_global_prompts,
   } from "$lib/listing-creation-slice";
@@ -87,7 +86,8 @@
     !listingCreation.hasCelebrated
   ) {
     console.log("[Celebration] Triggering! Batch:", completedBatchId);
-    store.dispatch(mark_celebrated()); // Record that we played it
+    // Persist celebration ack via broadcast so replay state knows this batch was celebrated.
+    dispatchBroadcast(mark_celebrated());
     showCelebration = true;
     showReturnToShopifyProducts = false;
     setTimeout(() => {
@@ -99,7 +99,6 @@
   }
 
   function handleGoToShopifyProducts() {
-    store.dispatch(clear_celebration());
     goto("/shopify-products");
   }
 

--- a/src/routes/listings/create/+page.svelte
+++ b/src/routes/listings/create/+page.svelte
@@ -79,7 +79,7 @@
   let variantPromptValue = "";
 
   let showCelebration = false;
-  let showReturnToDashboard = false;
+  let showReturnToShopifyProducts = false;
 
   $: completedBatchId = listingCreation.lastCompletedBatchId;
   $: if (
@@ -89,18 +89,18 @@
     console.log("[Celebration] Triggering! Batch:", completedBatchId);
     store.dispatch(mark_celebrated()); // Record that we played it
     showCelebration = true;
-    showReturnToDashboard = false;
+    showReturnToShopifyProducts = false;
     setTimeout(() => {
-      showReturnToDashboard = true;
+      showReturnToShopifyProducts = true;
     }, 3500); // Allow animation to play out
   } else if (completedBatchId === undefined) {
     showCelebration = false;
-    showReturnToDashboard = false;
+    showReturnToShopifyProducts = false;
   }
 
-  function handleReturnToDashboard() {
+  function handleGoToShopifyProducts() {
     store.dispatch(clear_celebration());
-    goto("/");
+    goto("/shopify-products");
   }
 
   // Derived
@@ -727,14 +727,14 @@
 
   {#if showCelebration}
     <Celebration />
-    {#if showReturnToDashboard}
+    {#if showReturnToShopifyProducts}
       <div class="celebration-action-overlay">
         <div class="celebration-action-container">
           <button
-            on:click={handleReturnToDashboard}
+            on:click={handleGoToShopifyProducts}
             class="btn-return-dashboard"
           >
-            Return to Dashboard
+            Go to Shopify Products
           </button>
         </div>
       </div>

--- a/tests/unit/listing-creation-celebration.test.ts
+++ b/tests/unit/listing-creation-celebration.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import reducer, {
+  complete_batch,
+  mark_celebrated,
+  start_batch,
+} from "$lib/listing-creation-slice";
+
+describe("Listing Creation - Celebration Gate", () => {
+  it("does not reset hasCelebrated on duplicate complete_batch with no active batch", () => {
+    const started = reducer(
+      undefined,
+      start_batch({
+        janCodes: ["JAN-1"],
+        batchId: "batch-1",
+        createdAt: 1,
+      }),
+    );
+
+    const completed = reducer(started, complete_batch());
+    expect(completed.lastCompletedBatchId).toBe("batch-1");
+    expect(completed.hasCelebrated).toBe(false);
+
+    const celebrated = reducer(completed, mark_celebrated());
+    expect(celebrated.hasCelebrated).toBe(true);
+
+    const duplicateComplete = reducer(celebrated, complete_batch());
+    expect(duplicateComplete.lastCompletedBatchId).toBe("batch-1");
+    expect(duplicateComplete.hasCelebrated).toBe(true);
+  });
+
+  it("resets celebration gate for a brand new batch completion", () => {
+    const base = reducer(undefined, { type: "@@INIT" });
+    const withPreviousCelebration = reducer(base, mark_celebrated());
+
+    const startedNext = reducer(
+      withPreviousCelebration,
+      start_batch({
+        janCodes: ["JAN-2"],
+        batchId: "batch-2",
+        createdAt: 2,
+      }),
+    );
+    expect(startedNext.hasCelebrated).toBe(false);
+
+    const completedNext = reducer(startedNext, complete_batch());
+    expect(completedNext.lastCompletedBatchId).toBe("batch-2");
+    expect(completedNext.hasCelebrated).toBe(false);
+  });
+});

--- a/tests/unit/listing-creation-celebration.test.ts
+++ b/tests/unit/listing-creation-celebration.test.ts
@@ -6,7 +6,7 @@ import reducer, {
 } from "$lib/listing-creation-slice";
 
 describe("Listing Creation - Celebration Gate", () => {
-  it("does not reset hasCelebrated on duplicate complete_batch with no active batch", () => {
+  it("keeps hasCelebrated=true after completion until the next start_batch", () => {
     const started = reducer(
       undefined,
       start_batch({
@@ -28,22 +28,27 @@ describe("Listing Creation - Celebration Gate", () => {
     expect(duplicateComplete.hasCelebrated).toBe(true);
   });
 
-  it("resets celebration gate for a brand new batch completion", () => {
-    const base = reducer(undefined, { type: "@@INIT" });
-    const withPreviousCelebration = reducer(base, mark_celebrated());
+  it("resets celebration gate only on start_batch", () => {
+    const startedFirst = reducer(
+      undefined,
+      start_batch({
+        janCodes: ["JAN-1"],
+        batchId: "batch-1",
+        createdAt: 1,
+      }),
+    );
+    const completedFirst = reducer(startedFirst, complete_batch());
+    const celebratedFirst = reducer(completedFirst, mark_celebrated());
+    expect(celebratedFirst.hasCelebrated).toBe(true);
 
-    const startedNext = reducer(
-      withPreviousCelebration,
+    const startedSecond = reducer(
+      celebratedFirst,
       start_batch({
         janCodes: ["JAN-2"],
         batchId: "batch-2",
         createdAt: 2,
       }),
     );
-    expect(startedNext.hasCelebrated).toBe(false);
-
-    const completedNext = reducer(startedNext, complete_batch());
-    expect(completedNext.lastCompletedBatchId).toBe("batch-2");
-    expect(completedNext.hasCelebrated).toBe(false);
+    expect(startedSecond.hasCelebrated).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- change Batch Completed CTA from dashboard to Shopify Products
- prevent celebration replay for duplicate completion events when no active batch exists
- add regression unit tests for celebration gate behavior
- update e2e expectation for the new CTA label and destination

## Testing
- npm run check
- pre-commit hooks (prettier/check/vitest) passed
- pre-push hooks passed:
  - test:live:doctor
  - test:live:vitest
  - test:live:e2e
  - test:e2e