### PR TITLE
#109 Shopify Order Sync Documentation

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -9,6 +9,7 @@ Architectural and design documents.
 - [Product Import Design](./PRODUCT_IMPORT_DESIGN.md)
 - [Shopify Listing Sync Audit Design](./SHOPIFY_LISTING_SYNC_AUDIT_DESIGN.md)
 - [Shopify Order Sync Design](./SHOPIFY_ORDER_SYNC_DESIGN.md)
+  - [Shopify Order Sync Implementation Plan](./SHOPIFY_ORDER_SYNC_IMPLEMENTATION_PLAN.md)
 - [Shopify Listings MVP Timestamp Comparison](./SHOPIFY_LISTINGS_MVP_TIMESTAMP_COMPARISON_DESIGN.md)
 - [Sync Lifecycle Events Proposal](./SYNC_LIFECYCLE_EVENTS_PROPOSAL.md)
 - [UI Overhaul](./UI_OVERHAUL.md)

--- a/docs/design/SHOPIFY_ORDER_SYNC_DESIGN.md
+++ b/docs/design/SHOPIFY_ORDER_SYNC_DESIGN.md
@@ -18,23 +18,29 @@ We need:
 
 This design strictly follows the "Facts vs. Intent" philosophy of the `admin2` architecture.
 
-- **Green Actions (Facts):** We only persist raw facts from Shopify into the `broadcast` collection.
+- **Green Actions (Facts):** We only persist raw facts from Shopify into the `broadcast` collection. These actions represent things that *happened* in Shopify, not the resulting state we want to reach.
 - **Actions:**
-  - `new_order`: Records the fact that a new order exists with specific metadata.
-  - `quantify_item`: Records the fact that a specific order line has a target quantity.
+  - `shopify_order_placed`: Records the fact that a new order was created with specific line items and quantities.
+  - `shopify_order_cancelled`: Records the fact that specific line items in an order were cancelled.
+  - `shopify_order_refunded`: Records the fact that specific line items in an order were refunded.
+  - `shopify_order_reconciled`: Records the current "ground truth" state of an order as reported by Shopify at a specific timestamp.
 
-By using `quantify_item` (target state) instead of incremental deltas, we ensure idempotency and allow for safe replay of the action log.
+By recording these raw facts, we ensure that if our business logic for calculating inventory impact (e.g., how to handle partial refunds) changes, we can simply replay the actions to reach the new correct state.
 
-## 3. Existing Local Model (important constraint)
+## 3. Reducer Responsibility
 
-Current inventory/order flow uses:
+The `Inventory` and `Orders` reducers are responsible for deriving the current state from these facts:
 
-- `new_order` to create/update `orderIdToOrder`.
-- `package_item` / `quantify_item` to update order line quantities and `item.shipped`.
+- **Inventory Reducer:** Calculates `committedQty` for an item by summing quantities from `shopify_order_placed` and subtracting quantities from `shopify_order_cancelled` and `shopify_order_refunded`.
+- **Orders Reducer:** Maintains the current state of an order by applying the sequence of Shopify events.
 
-`quantify_item` is useful for idempotent sync because it sets target quantity per order line (instead of always incrementing).
+The ingestion logic **must not** perform this calculation; it only maps the raw Shopify payload to these "Green" actions.
 
-## 3. Goals
+## 4. Existing Local Model (important constraint)
+
+Current inventory/order flow uses `new_order` and `package_item` / `quantify_item`. While `quantify_item` sets a target state, for the Shopify sync, we prefer the more granular "Green" actions described above to maintain a pure event log of external facts. The local reducers may internally use the same logic as `quantify_item` when processing a `shopify_order_reconciled` action.
+
+## 5. Goals
 
 - Sync Shopify orders into local orders.
 - Update inventory shipped quantities as orders come in.
@@ -65,60 +71,45 @@ Webhook receiver (Firebase Function):
 
 1. Verify Shopify HMAC signature.
 2. Deduplicate by webhook/event id.
-3. Parse order payload into canonical internal model.
-4. Dispatch broadcast actions:
-   - `new_order({ orderID, date, email, product })`
-   - per mapped line: `quantify_item({ orderID, itemKey, qty })`
-5. Record processing event/log.
+3. Parse order payload into "Green" actions:
+   - `shopify_order_placed({ orderID, date, email, lines: [{ itemKey, qty }] })`
+   - `shopify_order_cancelled({ orderID, lines: [{ itemKey, qty }] })`
+   - `shopify_order_refunded({ orderID, lines: [{ itemKey, qty }] })`
+4. Dispatch actions to the broadcast collection.
 
 Suggested initial topics:
 
-- `orders/create`
-- `orders/updated`
-- `orders/cancelled`
-- `refunds/create` (or equivalent order update handling with refunded quantities)
-
-References:
-
-- https://shopify.dev/docs/apps/build/webhooks/subscribe
-- https://shopify.dev/docs/api/admin-rest/2025-07/resources/webhook#event-topics-orders-create
+- `orders/create` -> `shopify_order_placed`
+- `orders/updated` -> logic to determine if it's a placement, cancellation, or refund
+- `orders/cancelled` -> `shopify_order_cancelled`
+- `refunds/create` -> `shopify_order_refunded`
 
 ### 6.2 Secondary path: Backfill/Reconciliation Poller
 
 Scheduled job (e.g. every 10-30 minutes):
 
 - Query Shopify orders by `updatedAt` cursor/window.
-- Recompute canonical desired order line quantities.
-- Re-apply `quantify_item` target state for each order.
+- For each order, fetch the full current state.
+- Dispatch `shopify_order_reconciled({ orderID, timestamp, lines: [{ itemKey, currentQty }] })`.
 
-This heals missed webhooks and guarantees eventual consistency.
+This action acts as a "ground truth" fact. When the reducer sees a reconciliation action with a later timestamp than the last event it processed for that order, it can use the `currentQty` to reset the order's state, effectively healing any missed webhooks.
 
 ## 7. Idempotency Strategy
 
 ### 7.1 Event-level dedupe
 
-Persist webhook/event ids in `shopify_order_events/{eventId}` with TTL retention.
+Persist webhook/event ids in `shopify_order_events/{eventId}` with TTL retention. If already processed, skip.
 
-If already processed, skip.
+### 7.2 Log-level idempotency
 
-### 7.2 State-level idempotency
-
-Always use `quantify_item` with target quantity per order line (not incremental deltas).
-
-This makes replays safe:
-
-- duplicate event -> no net change
-- out-of-order update -> later reconciliation corrects state
+By recording facts with Shopify-provided IDs (Order ID, Line Item ID, Refund ID), we ensure that re-processing the same fact log always produces the same result. The reducer uses these IDs to avoid double-counting.
 
 ## 8. Quantity Semantics
 
-Define one clear quantity policy in v1:
+The inventory impact is derived:
+`inventoryImpact = total_placed - total_cancelled - total_refunded`
 
-- `committedQty = paid/authorized quantity - cancelled - refunded`
-
-`committedQty` is what we mirror into local order lines and thus into `item.shipped` via `quantify_item`.
-
-If fulfillment-based semantics are preferred later, introduce policy versioning.
+The logic for this derivation lives in the `Inventory` reducer, not in the sync layer. This allows us to adjust how "refunded" items affect inventory (e.g., do they return to stock?) by changing the reducer logic and replaying the actions.
 
 ## 9. Data Model Additions
 

--- a/docs/design/SHOPIFY_ORDER_SYNC_DESIGN.md
+++ b/docs/design/SHOPIFY_ORDER_SYNC_DESIGN.md
@@ -148,7 +148,7 @@ shopify_orders_mirror/{shopifyOrderId} {
 
 1. Implement webhook receiver + HMAC validation + dedupe store.
 2. Implement mapping layer from Shopify line items -> local item keys.
-3. Dispatch `new_order` + `quantify_item` actions via broadcast.
+3. Dispatch `shopify_order_*` actions via broadcast.
 4. Add reconciliation poller using `updatedAt` cursor.
 5. Add UI visibility for sync exceptions and last order sync health.
 

--- a/docs/design/SHOPIFY_ORDER_SYNC_DESIGN.md
+++ b/docs/design/SHOPIFY_ORDER_SYNC_DESIGN.md
@@ -1,6 +1,7 @@
 # Shopify Order Sync Design
 
-> **Status: Proposed** - Ingest Shopify orders into our event-sourced system and update inventory as orders arrive.
+> **Status: Active** - Ingest Shopify orders into our event-sourced system and update inventory as orders arrive.
+> **Implementation Plan:** [SHOPIFY_ORDER_SYNC_IMPLEMENTATION_PLAN.md](SHOPIFY_ORDER_SYNC_IMPLEMENTATION_PLAN.md)
 
 ## 1. Problem
 
@@ -13,7 +14,18 @@ We need:
 - Safe replay/idempotency.
 - Recovery when webhooks are missed.
 
-## 2. Existing Local Model (important constraint)
+## 2. "Facts vs. Intent" Philosophy
+
+This design strictly follows the "Facts vs. Intent" philosophy of the `admin2` architecture.
+
+- **Green Actions (Facts):** We only persist raw facts from Shopify into the `broadcast` collection.
+- **Actions:**
+  - `new_order`: Records the fact that a new order exists with specific metadata.
+  - `quantify_item`: Records the fact that a specific order line has a target quantity.
+
+By using `quantify_item` (target state) instead of incremental deltas, we ensure idempotency and allow for safe replay of the action log.
+
+## 3. Existing Local Model (important constraint)
 
 Current inventory/order flow uses:
 

--- a/docs/design/SHOPIFY_ORDER_SYNC_IMPLEMENTATION_PLAN.md
+++ b/docs/design/SHOPIFY_ORDER_SYNC_IMPLEMENTATION_PLAN.md
@@ -46,30 +46,22 @@ Implement a robust, idempotent ingestion pipeline for Shopify orders that update
 - If SKU is missing or invalid, attempt fallback to JAN code in product properties or title.
 
 ### 3.2 Dispatching "Green" Actions
-- Construct and dispatch `new_order` action:
+- Construct and dispatch raw fact actions:
     ```json
     {
-      "type": "new_order",
+      "type": "shopify_order_placed",
       "payload": {
         "orderID": "shopify:<order_id>",
         "date": "2023-10-27T...",
         "email": "customer@example.com",
-        "product": "Shopify Order #1001"
+        "lines": [
+          { "itemKey": "<inventory_item_key>", "qty": 1, "lineItemID": "<shopify_line_id>" }
+        ]
       }
     }
     ```
-- For each mapped line item, dispatch `quantify_item`:
-    ```json
-    {
-      "type": "quantify_item",
-      "payload": {
-        "orderID": "shopify:<order_id>",
-        "itemKey": "<inventory_item_key>",
-        "qty": <committed_quantity>
-      }
-    }
-    ```
-- **Idempotency:** Use Shopify's internal `id` (stringified) for the local `orderID` key to ensure that re-processing the same order always updates the same local record.
+- Similarly for cancellations and refunds, dispatch `shopify_order_cancelled` or `shopify_order_refunded` with raw quantities and IDs.
+- **Idempotency:** The reducer uses the Shopify `orderID`, `lineItemID`, and `refundID` to ensure that it only counts each fact once, even if the action is replayed.
 
 ## Phase 4: Reconciliation Poller
 
@@ -79,8 +71,20 @@ Implement a robust, idempotent ingestion pipeline for Shopify orders that update
 - Use the `updated_at_min` filter based on a stored `lastOrderUpdatedAtCursor`.
 
 ### 4.2 Healing Logic
-- The poller should re-calculate the `committed_quantity` for all lines and re-dispatch `quantify_item`.
-- Since `quantify_item` is state-based (target quantity), it will automatically correct any discrepancies caused by missed webhooks without introducing duplicates.
+- The poller dispatches a `shopify_order_reconciled` action:
+    ```json
+    {
+      "type": "shopify_order_reconciled",
+      "payload": {
+        "orderID": "shopify:<order_id>",
+        "timestamp": 1700000000000,
+        "lines": [
+          { "itemKey": "<item_key>", "currentQty": 2 }
+        ]
+      }
+    }
+    ```
+- **Ground Truth:** The `Inventory` reducer treats this as the definitive state of the order at that timestamp. If the reducer's last processed event for this order is older than the reconciliation timestamp, it overrides its internal counters with these values.
 
 ## Phase 5: Testing & Verification
 
@@ -89,12 +93,13 @@ Implement a robust, idempotent ingestion pipeline for Shopify orders that update
 2. **Order Placement:** Place a test order in the dev store.
     - Verify `shopifyOrderWebhook` is triggered.
     - Verify raw payload is written to Firestore.
-    - Verify `new_order` and `quantify_item` actions appear in the `broadcast` log.
-    - Verify local Redux state (`inventory` and `listings` slices) reflects the new `shipped` quantities.
-3. **Updates & Cancellations:** Modify a test order (e.g., change quantity, cancel it).
-    - Verify local state updates correctly via `quantify_item` (e.g., quantity drops to 0 on cancellation).
+    - Verify `shopify_order_placed` action appears in the `broadcast` log.
+    - Verify local Redux state reflects the new inventory impact (derived by the reducer).
+3. **Updates & Cancellations:** Modify a test order (e.g., cancel it).
+    - Verify `shopify_order_cancelled` is broadcasted.
+    - Verify local state updates correctly as the reducer processes the cancellation fact.
 4. **Refunds:** Issue a partial refund.
-    - Verify `committed_quantity` logic correctly subtracts refunded items.
+    - Verify `shopify_order_refunded` is broadcasted and inventory impact is adjusted by the reducer.
 
 ### 5.2 Automated E2E Test (Mocked)
 - Create a new Playwright test in `e2e/016-shopify-sync/`.

--- a/docs/design/SHOPIFY_ORDER_SYNC_IMPLEMENTATION_PLAN.md
+++ b/docs/design/SHOPIFY_ORDER_SYNC_IMPLEMENTATION_PLAN.md
@@ -7,7 +7,7 @@ This document outlines the detailed implementation and testing plan for the Shop
 
 ## Goal
 
-Implement a robust, idempotent ingestion pipeline for Shopify orders that updates local inventory state using "Green" actions (`new_order`, `quantify_item`).
+Implement a robust, idempotent ingestion pipeline for Shopify orders that updates local inventory state using "Green" actions (`shopify_order_placed`, `shopify_order_cancelled`, and `shopify_order_refunded`).
 
 ## Phase 1: Environment Setup
 

--- a/docs/design/SHOPIFY_ORDER_SYNC_IMPLEMENTATION_PLAN.md
+++ b/docs/design/SHOPIFY_ORDER_SYNC_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,105 @@
+# Shopify Order Sync Implementation Plan
+
+> **Status: Draft**
+> **Related Design:** [SHOPIFY_ORDER_SYNC_DESIGN.md](SHOPIFY_ORDER_SYNC_DESIGN.md)
+
+This document outlines the detailed implementation and testing plan for the Shopify Order Sync feature.
+
+## Goal
+
+Implement a robust, idempotent ingestion pipeline for Shopify orders that updates local inventory state using "Green" actions (`new_order`, `quantify_item`).
+
+## Phase 1: Environment Setup
+
+### 1.1 Shopify Development Store
+- Create a new development store in the Shopify Partner Dashboard (or use an existing one).
+- Populate the store with test products that have SKUs matching existing `InventoryItemKey` formats in our local environment (e.g., `JANCODE:SUBTYPE`).
+
+### 1.2 Custom App Creation
+- Create a Custom App in the Shopify Admin.
+- Configure **Admin API integration** with the following scopes:
+    - `read_orders`
+    - `read_products`
+    - `read_inventory`
+- Store the **Admin API Access Token** and **API Secret Key** (for HMAC verification) securely.
+
+### 1.3 Local Webhook Testing
+- Use a tunnel service (e.g., `ngrok` or `cloudflared`) to expose the local Firebase Functions emulator port (typically `5001`).
+- Configure Shopify Webhooks (`orders/create`, `orders/updated`, `orders/cancelled`) to point to the tunnel URL: `https://<tunnel-id>.ngrok-free.app/<project-id>/us-central1/shopifyOrderWebhook`.
+
+## Phase 2: Ingestion Logic
+
+### 2.1 Firebase Function: `shopifyOrderWebhook`
+- Implement a new Firebase Function (v2) `shopifyOrderWebhook`.
+- **HMAC Verification:** Validate every request using the `X-Shopify-Hmac-Sha256` header and the stored API Secret Key.
+- **Raw Persistence:** Write the raw payload to a `shopify_order_webhooks` collection *before* processing. This ensures we can re-process if the logic changes (following the "Facts" philosophy).
+- **Deduplication:** Check `shopify_order_events/{shopify_event_id}` to prevent duplicate processing.
+
+### 2.2 Error Handling
+- Capture mapping failures (e.g., unknown SKU) in a `shopify_sync_errors` collection for visibility in the admin UI.
+
+## Phase 3: Event Mapping & Broadcasting
+
+### 3.1 Mapping Shopify to Local Model
+- Extract `line_items` from the Shopify payload.
+- Map `line_item.sku` to local `InventoryItemKey`.
+- If SKU is missing or invalid, attempt fallback to JAN code in product properties or title.
+
+### 3.2 Dispatching "Green" Actions
+- Construct and dispatch `new_order` action:
+    ```json
+    {
+      "type": "new_order",
+      "payload": {
+        "orderID": "shopify:<order_id>",
+        "date": "2023-10-27T...",
+        "email": "customer@example.com",
+        "product": "Shopify Order #1001"
+      }
+    }
+    ```
+- For each mapped line item, dispatch `quantify_item`:
+    ```json
+    {
+      "type": "quantify_item",
+      "payload": {
+        "orderID": "shopify:<order_id>",
+        "itemKey": "<inventory_item_key>",
+        "qty": <committed_quantity>
+      }
+    }
+    ```
+- **Idempotency:** Use Shopify's internal `id` (stringified) for the local `orderID` key to ensure that re-processing the same order always updates the same local record.
+
+## Phase 4: Reconciliation Poller
+
+### 4.1 Scheduled Function: `shopifyOrderReconcile`
+- Implement a `pubsub` scheduled function (e.g., every 15 minutes).
+- Fetch recent orders via the Shopify Admin REST or GraphQL API.
+- Use the `updated_at_min` filter based on a stored `lastOrderUpdatedAtCursor`.
+
+### 4.2 Healing Logic
+- The poller should re-calculate the `committed_quantity` for all lines and re-dispatch `quantify_item`.
+- Since `quantify_item` is state-based (target quantity), it will automatically correct any discrepancies caused by missed webhooks without introducing duplicates.
+
+## Phase 5: Testing & Verification
+
+### 5.1 Manual Verification (Dev Store)
+1. **Initial Sync:** Run the reconciliation poller and verify existing dev store orders appear in local state.
+2. **Order Placement:** Place a test order in the dev store.
+    - Verify `shopifyOrderWebhook` is triggered.
+    - Verify raw payload is written to Firestore.
+    - Verify `new_order` and `quantify_item` actions appear in the `broadcast` log.
+    - Verify local Redux state (`inventory` and `listings` slices) reflects the new `shipped` quantities.
+3. **Updates & Cancellations:** Modify a test order (e.g., change quantity, cancel it).
+    - Verify local state updates correctly via `quantify_item` (e.g., quantity drops to 0 on cancellation).
+4. **Refunds:** Issue a partial refund.
+    - Verify `committed_quantity` logic correctly subtracts refunded items.
+
+### 5.2 Automated E2E Test (Mocked)
+- Create a new Playwright test in `e2e/016-shopify-sync/`.
+- Mock the Shopify webhook payload.
+- Verify the UI reflects the inventory changes without a full page reload (testing the real-time broadcast).
+
+### 5.3 Rollout Verification
+- Before deploying to production, run a "Dry Run" sync where actions are calculated but not broadcasted, logging the expected changes to `stdout` for manual review.

--- a/docs/integrations/SHOPIFY_INTEGRATION.md
+++ b/docs/integrations/SHOPIFY_INTEGRATION.md
@@ -162,13 +162,13 @@ _Goal: Keep Shopify inventory correct._
 
 _Goal: Record orders as actions using "Facts vs. Intent" philosophy._
 
-1.  **Webhook**: Receive `orders/create`, `orders/updated`, `orders/cancelled`.
+1.  **Webhook**: Receive `orders/create`, `orders/updated`, `orders/cancelled`, `refunds/create`.
 2.  **Translate**: Convert Shopify Line Items -> Internal Item Keys.
 3.  **Dispatch**:
-    - Dispatch `new_order` action with order metadata.
-    - Dispatch `quantify_item` for each line item to set the target committed quantity.
+    - Dispatch `shopify_order_placed` action with order metadata and raw quantities.
+    - Dispatch `shopify_order_cancelled` / `shopify_order_refunded` as events occur.
     - Dispatch `shopify_api_log` recording the webhook receipt.
-4.  **Inventory Impact**: `quantify_item` updates the order line state, which is factored into the `Total Shipped` calculation, automatically reducing `Available Stock` and triggering Workflow B (Inventory Sync) to update Shopify.
+4.  **Inventory Impact**: The `Inventory` reducer processes these facts to derive the `Total Shipped` calculation, which automatically updates `Available Stock` and triggers Workflow B (Inventory Sync) to update Shopify.
 
 See [SHOPIFY_ORDER_SYNC_DESIGN.md](../design/SHOPIFY_ORDER_SYNC_DESIGN.md) for details.
 

--- a/docs/integrations/SHOPIFY_INTEGRATION.md
+++ b/docs/integrations/SHOPIFY_INTEGRATION.md
@@ -160,14 +160,17 @@ _Goal: Keep Shopify inventory correct._
 
 ### C. Order Import (Shopify -> Admin)
 
-_Goal: Record orders as actions._
+_Goal: Record orders as actions using "Facts vs. Intent" philosophy._
 
-1.  **Webhook**: Receive `orders/create`.
-2.  **Translate**: Convert Shopify Line Items -> Internal Item Keys (using `ShopifyState`).
+1.  **Webhook**: Receive `orders/create`, `orders/updated`, `orders/cancelled`.
+2.  **Translate**: Convert Shopify Line Items -> Internal Item Keys.
 3.  **Dispatch**:
-    - Dispatch `create_order` action.
+    - Dispatch `new_order` action with order metadata.
+    - Dispatch `quantify_item` for each line item to set the target committed quantity.
     - Dispatch `shopify_api_log` recording the webhook receipt.
-4.  **Fulfillment**: When items are shipped, `Available Stock` decreases, automatically triggering Workflow B.
+4.  **Inventory Impact**: `quantify_item` updates the order line state, which is factored into the `Total Shipped` calculation, automatically reducing `Available Stock` and triggering Workflow B (Inventory Sync) to update Shopify.
+
+See [SHOPIFY_ORDER_SYNC_DESIGN.md](../design/SHOPIFY_ORDER_SYNC_DESIGN.md) for details.
 
 ### D. Manual Content Merge
 


### PR DESCRIPTION
This PR updates the Shopify Order Sync design and adds a detailed implementation plan with a focus on testing, as requested in #109.

Changes:
- Updated `docs/design/SHOPIFY_ORDER_SYNC_DESIGN.md` to reflect 'Active' status and 'Facts vs. Intent' philosophy.
- Created `docs/design/SHOPIFY_ORDER_SYNC_IMPLEMENTATION_PLAN.md` with a detailed phased rollout and testing strategy.
- Updated `docs/integrations/SHOPIFY_INTEGRATION.md` and `docs/design/README.md` to link to the new documentation.

Closes #109