### PR TITLE
[codex] add live event sales import

### DIFF
--- a/docs/design/LIVE_EVENT_SALES_IMPORT_DESIGN.md
+++ b/docs/design/LIVE_EVENT_SALES_IMPORT_DESIGN.md
@@ -1,0 +1,99 @@
+# Live Event Sales Import Design
+
+> **Status: Implemented** - Manual pasted TSV/CSV import for sales counted at live events.
+
+## Problem
+
+Live event sales are currently reconciled outside the main import workflows. The source data is usually a copied spreadsheet with inventory taken to the event, inventory returned from the event, and a sold count per JAN/subtype row.
+
+We need a flow that:
+
+- accepts pasted TSV or CSV directly in the browser;
+- previews the rows before inventory is changed;
+- lets the user approve or unapprove rows interactively;
+- commits approved sales into the same inventory/order model used by other sales flows;
+- keeps the pasted text as the durable source fact so replay can benefit from parser and reducer fixes.
+
+## Source Fact
+
+The persisted fact is the raw pasted text:
+
+```ts
+liveEventImport / set_paste({ rawPaste });
+```
+
+The reducer parses the paste into review rows. It stores the original paste, detected delimiter, inferred event name, row errors, warnings, and default row approval state. The UI does not persist an import plan.
+
+Supported columns include:
+
+- `janCode`
+- `subtype`
+- `description`
+- `image`
+- `hsCode`
+- `qty`
+- `pieces`
+- `shipped`
+- `Inventory Count per system`
+- `Actual inventory count in office`
+- `Taking to <event name>`
+- `Returned from <event name>`
+- `Sold`
+
+`Sold` is authoritative when present. If `Sold` is missing, the reducer derives sold quantity from `Taking to ... - Returned from ...`. If both are present and disagree, the reducer keeps `Sold` and records a warning.
+
+## Reducer Responsibility
+
+`live-event-import-slice.ts` owns paste parsing and row approval state. It does not write inventory directly.
+
+The root reducer intercepts:
+
+```ts
+liveEventImport / commit_import();
+```
+
+From the current pasted rows plus current inventory, it computes approved sale lines, synthesizes a `new_order` for the event, synthesizes `package_item` actions for each sold inventory item, and marks committed rows done.
+
+This keeps the irreversible inventory effect derived from replayable state:
+
+1. raw paste fact;
+2. approval intents;
+3. commit intent;
+4. reducer-computed order/package actions.
+
+## Matching Rules
+
+Rows match inventory in this order:
+
+1. exact local inventory key: `makeInventoryItemKey(janCode, subtype)`;
+2. unique JAN fallback when exactly one inventory item has the pasted JAN.
+
+Rows with no match remain visible and are not committed. A row with `Sold = 0` can be committed and marked done, but it does not synthesize a package action.
+
+## UI
+
+The `/live-event-import` route provides:
+
+- a paste area for TSV/CSV;
+- summary counts for approved rows, committed rows, and rows needing attention;
+- a review table with image, item identifiers, count columns, sold quantity, current available count, and projected available count;
+- approval checkboxes per row plus approve all / unapprove all controls;
+- a commit button for approved valid rows.
+
+Oversold rows are warned but not blocked because the live count may be the physical source of truth. Missing inventory matches are blocked until unapproved or fixed by changing inventory/source data.
+
+## Non-goals
+
+- Editing pasted cell values in derived state.
+- Creating new inventory items from live event sales rows.
+- Replacing Shopify/Etsy order sync or the older archive-based show sales view.
+
+## Rollout Notes
+
+The feature is additive:
+
+- new `liveEventImport` Redux slice;
+- new `/live-event-import` route;
+- root reducer interception for commit;
+- navigation entry;
+- unit coverage for parsing and commit computation.

--- a/src/lib/components/Navigation.svelte
+++ b/src/lib/components/Navigation.svelte
@@ -45,6 +45,7 @@
     { href: "/itemhistory", label: "Item History", icon: History },
     { href: "/jancodes", label: "Jan Codes", icon: Barcode },
     { href: "/order-import", label: "Order Import", icon: Import },
+    { href: "/live-event-import", label: "Live Event Import", icon: Import },
     { href: "/photo-history", label: "Photo History", icon: Image },
     { href: "/photos", label: "Photos", icon: Camera },
     { href: "/shopify-import", label: "Shopify Import", icon: Import },

--- a/src/lib/live-event-import-slice.ts
+++ b/src/lib/live-event-import-slice.ts
@@ -1,6 +1,6 @@
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 import Papa from "papaparse";
-import { makeInventoryItemKey } from "./sku";
+import { canonicalizeSubtype, makeInventoryItemKey } from "./sku";
 
 export interface LiveEventImportItem {
   janCode: string;
@@ -39,6 +39,12 @@ export interface LiveEventCommitLine {
   index: number;
   itemKey: string;
   qty: number;
+}
+
+export interface LiveEventInventoryMatch {
+  key: string;
+  item: any;
+  matchType: "exact" | "jan";
 }
 
 export const initialState: LiveEventImportState = {
@@ -276,20 +282,33 @@ export const parseLiveEventPaste = (
   return { delimiter, eventName, rows };
 };
 
-const findInventoryMatch = (
+const hasBlankOrDefaultSubtype = (subtype?: string): boolean =>
+  canonicalizeSubtype(subtype) === "";
+
+export const findLiveEventInventoryMatch = (
   item: LiveEventImportItem,
   inventoryIdToItem: Record<string, any>,
-): string | null => {
+): LiveEventInventoryMatch | null => {
   const exactKey = makeInventoryItemKey(item.janCode, item.subtype);
-  if (inventoryIdToItem[exactKey]) return exactKey;
+  const exact = inventoryIdToItem[exactKey];
+  if (exact) return { key: exactKey, item: exact, matchType: "exact" };
+
+  if (!hasBlankOrDefaultSubtype(item.subtype)) return null;
 
   const janMatches = Object.entries(inventoryIdToItem)
     .filter(([, inventoryItem]: [string, any]) => {
-      return String(inventoryItem?.janCode || "").trim() === item.janCode;
+      return (
+        String(inventoryItem?.janCode || "").trim() === item.janCode &&
+        hasBlankOrDefaultSubtype(inventoryItem?.subtype)
+      );
     })
-    .map(([key]) => key);
+    .map(([key, inventoryItem]) => ({ key, item: inventoryItem }));
 
-  return janMatches.length === 1 ? janMatches[0] : null;
+  if (janMatches.length === 1) {
+    return { ...janMatches[0], matchType: "jan" };
+  }
+
+  return null;
 };
 
 export const computeLiveEventImportCommit = (
@@ -304,11 +323,11 @@ export const computeLiveEventImportCommit = (
     const sold = Number(row.parsed.sold || 0);
     if (!Number.isInteger(sold) || sold < 0) return;
 
-    const itemKey = findInventoryMatch(row.parsed, inventoryIdToItem);
-    if (!itemKey) return;
+    const match = findLiveEventInventoryMatch(row.parsed, inventoryIdToItem);
+    if (!match) return;
 
     if (sold > 0) {
-      lines.push({ index, itemKey, qty: sold });
+      lines.push({ index, itemKey: match.key, qty: sold });
     }
     indices.push(index);
   });

--- a/src/lib/live-event-import-slice.ts
+++ b/src/lib/live-event-import-slice.ts
@@ -1,0 +1,378 @@
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+import Papa from "papaparse";
+import { makeInventoryItemKey } from "./sku";
+
+export interface LiveEventImportItem {
+  janCode: string;
+  subtype: string;
+  description: string;
+  image?: string;
+  hsCode?: string;
+  qty?: number;
+  pieces?: number;
+  shipped?: number;
+  systemCount?: number;
+  actualOfficeCount?: number;
+  taking?: number;
+  returned?: number;
+  sold: number;
+}
+
+export interface LiveEventRawRow {
+  raw: string;
+  parsed: LiveEventImportItem | null;
+  error?: string;
+  warnings?: string[];
+  approved: boolean;
+  processed?: boolean;
+}
+
+export interface LiveEventImportState {
+  rawPaste: string;
+  delimiter: "csv" | "tsv" | "unknown";
+  eventName: string;
+  step: "idle" | "review";
+  rows: LiveEventRawRow[];
+}
+
+export interface LiveEventCommitLine {
+  index: number;
+  itemKey: string;
+  qty: number;
+}
+
+export const initialState: LiveEventImportState = {
+  rawPaste: "",
+  delimiter: "unknown",
+  eventName: "",
+  step: "idle",
+  rows: [],
+};
+
+const normalizeHeaderKey = (key: string): string =>
+  key
+    .normalize("NFKC")
+    .replace(/\uFEFF/g, "")
+    .toLowerCase()
+    .replace(/[\r\n]+/g, " ")
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+const getCells = (row: Record<string, unknown>) =>
+  Object.entries(row)
+    .filter(([key]) => key !== "__parsed_extra" && key !== "")
+    .map(([key, value]) => ({
+      key,
+      normalizedKey: normalizeHeaderKey(key),
+      value: String(value ?? "").trim(),
+    }));
+
+const findCell = (
+  row: Record<string, unknown>,
+  predicates: Array<(normalizedHeader: string) => boolean>,
+): string | undefined => {
+  for (const cell of getCells(row)) {
+    if (predicates.some((predicate) => predicate(cell.normalizedKey))) {
+      return cell.value;
+    }
+  }
+  return undefined;
+};
+
+const parseOptionalNumber = (value: string | undefined): number | undefined => {
+  if (value === undefined || value.trim() === "") return undefined;
+  const cleaned = value.replace(/,/g, "").replace(/[^0-9.-]/g, "");
+  if (!cleaned) return undefined;
+  const parsed = Number.parseFloat(cleaned);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const parseRequiredNumber = (value: string | undefined): number | undefined => {
+  const parsed = parseOptionalNumber(value);
+  return parsed === undefined ? undefined : parsed;
+};
+
+const findEventName = (headers: string[]): string => {
+  for (const header of headers) {
+    const cleaned = header
+      .normalize("NFKC")
+      .replace(/\uFEFF/g, "")
+      .replace(/[\r\n]+/g, " ")
+      .replace(/\s+/g, " ")
+      .trim();
+    const taking = cleaned.match(/^taking\s+to\s+(.+)$/i);
+    if (taking?.[1]) return taking[1].trim();
+  }
+  for (const header of headers) {
+    const cleaned = header
+      .normalize("NFKC")
+      .replace(/\uFEFF/g, "")
+      .replace(/[\r\n]+/g, " ")
+      .replace(/\s+/g, " ")
+      .trim();
+    const returned = cleaned.match(/^returned\s+from\s+(.+)$/i);
+    if (returned?.[1]) return returned[1].trim();
+  }
+  return "";
+};
+
+const isEmptyParsedRow = (row: Record<string, unknown>): boolean =>
+  getCells(row).every((cell) => cell.value === "");
+
+const mapLiveEventItem = (
+  row: Record<string, unknown>,
+): {
+  item: LiveEventImportItem | null;
+  error?: string;
+  warnings?: string[];
+} => {
+  if (isEmptyParsedRow(row)) return { item: null };
+
+  const janCode = (
+    findCell(row, [
+      (h) => h === "jancode",
+      (h) => h === "jan code",
+      (h) => h === "jan",
+      (h) => h === "sku",
+      (h) => h === "variant sku",
+    ]) || ""
+  )
+    .trim()
+    .replace(/\s+/g, "");
+  const subtype = (
+    findCell(row, [
+      (h) => h === "subtype",
+      (h) => h === "variant",
+      (h) => h === "option1 value",
+      (h) => h === "option value",
+    ]) || ""
+  ).trim();
+  const description = (
+    findCell(row, [
+      (h) => h === "description",
+      (h) => h === "title",
+      (h) => h === "product name",
+      (h) => h === "item name",
+      (h) => h === "product",
+    ]) || ""
+  ).trim();
+  const taking = parseOptionalNumber(
+    findCell(row, [(h) => h.startsWith("taking to ")]),
+  );
+  const returned = parseOptionalNumber(
+    findCell(row, [(h) => h.startsWith("returned from ")]),
+  );
+  const explicitSold = parseRequiredNumber(
+    findCell(row, [
+      (h) => h === "sold",
+      (h) => h === "qty sold",
+      (h) => h === "quantity sold",
+      (h) => h === "sales",
+    ]),
+  );
+  const derivedSold =
+    taking !== undefined && returned !== undefined
+      ? taking - returned
+      : undefined;
+  const sold = explicitSold ?? derivedSold;
+  const warnings: string[] = [];
+
+  if (
+    explicitSold !== undefined &&
+    derivedSold !== undefined &&
+    explicitSold !== derivedSold
+  ) {
+    warnings.push(
+      `Sold (${explicitSold}) does not match taking minus returned (${derivedSold}).`,
+    );
+  }
+
+  let error: string | undefined;
+  if (!janCode) {
+    error = "Missing JAN code";
+  } else if (sold === undefined) {
+    error = "Missing sold quantity";
+  } else if (!Number.isInteger(sold)) {
+    error = "Sold quantity must be a whole number";
+  } else if (sold < 0) {
+    error = "Sold quantity cannot be negative";
+  }
+
+  const item: LiveEventImportItem | null =
+    sold === undefined
+      ? null
+      : {
+          janCode,
+          subtype,
+          description,
+          image: findCell(row, [
+            (h) => h === "image",
+            (h) => h === "image src",
+          ]),
+          hsCode: findCell(row, [
+            (h) => h === "hscode",
+            (h) => h === "hs code",
+          ]),
+          qty: parseOptionalNumber(findCell(row, [(h) => h === "qty"])),
+          pieces: parseOptionalNumber(findCell(row, [(h) => h === "pieces"])),
+          shipped: parseOptionalNumber(findCell(row, [(h) => h === "shipped"])),
+          systemCount: parseOptionalNumber(
+            findCell(row, [
+              (h) => h === "inventory count per system",
+              (h) => h === "system count",
+            ]),
+          ),
+          actualOfficeCount: parseOptionalNumber(
+            findCell(row, [
+              (h) => h === "actual inventory count in office",
+              (h) => h === "actual office count",
+            ]),
+          ),
+          taking,
+          returned,
+          sold,
+        };
+
+  return { item, error, warnings };
+};
+
+export const parseLiveEventPaste = (
+  rawPaste: string,
+): Pick<LiveEventImportState, "delimiter" | "eventName" | "rows"> => {
+  const trimmed = rawPaste.trim();
+  const delimiter = trimmed.includes("\t")
+    ? "tsv"
+    : trimmed
+      ? "csv"
+      : "unknown";
+  if (!trimmed) {
+    return { delimiter: "unknown", eventName: "", rows: [] };
+  }
+
+  const result = Papa.parse<Record<string, unknown>>(trimmed, {
+    header: true,
+    skipEmptyLines: "greedy",
+    delimiter: delimiter === "tsv" ? "\t" : "",
+  });
+  const headers = result.meta.fields || [];
+  const eventName = findEventName(headers);
+  const sourceLines = trimmed.split(/\r?\n/).slice(1);
+  const rows: LiveEventRawRow[] = [];
+
+  result.data.forEach((row, index) => {
+    const mapped = mapLiveEventItem(row);
+    if (!mapped.item && !mapped.error) return;
+
+    rows.push({
+      raw: sourceLines[index] || "",
+      parsed: mapped.item,
+      error: mapped.error,
+      warnings: mapped.warnings,
+      approved: !mapped.error,
+    });
+  });
+
+  return { delimiter, eventName, rows };
+};
+
+const findInventoryMatch = (
+  item: LiveEventImportItem,
+  inventoryIdToItem: Record<string, any>,
+): string | null => {
+  const exactKey = makeInventoryItemKey(item.janCode, item.subtype);
+  if (inventoryIdToItem[exactKey]) return exactKey;
+
+  const janMatches = Object.entries(inventoryIdToItem)
+    .filter(([, inventoryItem]: [string, any]) => {
+      return String(inventoryItem?.janCode || "").trim() === item.janCode;
+    })
+    .map(([key]) => key);
+
+  return janMatches.length === 1 ? janMatches[0] : null;
+};
+
+export const computeLiveEventImportCommit = (
+  state: LiveEventImportState,
+  inventoryIdToItem: Record<string, any>,
+): { lines: LiveEventCommitLine[]; indices: number[] } => {
+  const lines: LiveEventCommitLine[] = [];
+  const indices: number[] = [];
+
+  state.rows.forEach((row, index) => {
+    if (row.processed || !row.approved || row.error || !row.parsed) return;
+    const sold = Number(row.parsed.sold || 0);
+    if (!Number.isInteger(sold) || sold < 0) return;
+
+    const itemKey = findInventoryMatch(row.parsed, inventoryIdToItem);
+    if (!itemKey) return;
+
+    if (sold > 0) {
+      lines.push({ index, itemKey, qty: sold });
+    }
+    indices.push(index);
+  });
+
+  return { lines, indices };
+};
+
+const liveEventImportSlice = createSlice({
+  name: "liveEventImport",
+  initialState,
+  reducers: {
+    set_paste: (state, action: PayloadAction<{ rawPaste: string }>) => {
+      const parsed = parseLiveEventPaste(action.payload.rawPaste);
+      state.rawPaste = action.payload.rawPaste;
+      state.delimiter = parsed.delimiter;
+      state.eventName = parsed.eventName;
+      state.rows = parsed.rows;
+      state.step = parsed.rows.length > 0 ? "review" : "idle";
+    },
+    toggle_row_approval: (
+      state,
+      action: PayloadAction<{ index: number; approved?: boolean }>,
+    ) => {
+      const row = state.rows[action.payload.index];
+      if (!row || row.error || row.processed) return;
+      row.approved = action.payload.approved ?? !row.approved;
+    },
+    set_all_approvals: (
+      state,
+      action: PayloadAction<{ approved: boolean }>,
+    ) => {
+      state.rows.forEach((row) => {
+        if (!row.error && !row.processed) {
+          row.approved = action.payload.approved;
+        }
+      });
+    },
+    mark_rows_done: (state, action: PayloadAction<{ indices: number[] }>) => {
+      action.payload.indices.forEach((index) => {
+        if (state.rows[index]) {
+          state.rows[index].processed = true;
+          state.rows[index].approved = false;
+        }
+      });
+    },
+    clear_import: (state) => {
+      state.rawPaste = "";
+      state.delimiter = "unknown";
+      state.eventName = "";
+      state.step = "idle";
+      state.rows = [];
+    },
+    commit_import: (state) => {
+      // Root reducer derives inventory/order effects from the pasted fact.
+    },
+  },
+});
+
+export const {
+  set_paste,
+  toggle_row_approval,
+  set_all_approvals,
+  mark_rows_done,
+  clear_import,
+  commit_import,
+} = liveEventImportSlice.actions;
+export const liveEventImport = liveEventImportSlice.reducer;

--- a/src/lib/root-reducer.ts
+++ b/src/lib/root-reducer.ts
@@ -6,6 +6,8 @@ import {
   type BulkImportItem,
   type Item,
   update_field,
+  new_order,
+  package_item,
   split_inventory_item,
   fix_jancode,
 } from "./inventory";
@@ -21,6 +23,11 @@ import {
   computeShopifyImportBatch,
   mark_items_done as markShopifyDone,
 } from "./shopify-import-slice";
+import {
+  liveEventImport,
+  computeLiveEventImportCommit,
+  mark_rows_done as markLiveEventRowsDone,
+} from "./live-event-import-slice";
 import {
   listings,
   add_listing_image,
@@ -70,6 +77,7 @@ const reducerObject = {
   photos,
   orderImport,
   shopifyImport,
+  liveEventImport,
   listings,
   shopifySync,
   shopifyCatalog,
@@ -1159,6 +1167,69 @@ export const rootReducer = (
         shopifyImport: shopifyImport(nextState.shopifyImport, markAction),
       };
       logger(markAction, nextState, action._timestamp); // LOG SUB-ACTION
+    }
+  }
+
+  // Live Event Sales Import
+  if (
+    action.type === "liveEventImport/commit_import" &&
+    nextState.liveEventImport
+  ) {
+    const { lines, indices } = computeLiveEventImportCommit(
+      nextState.liveEventImport,
+      nextState.inventory.idToItem,
+    );
+
+    if (lines.length > 0) {
+      const eventName =
+        String(nextState.liveEventImport.eventName || "").trim() ||
+        "Live Event";
+      const eventSlug = eventName
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "");
+      const orderID = `live-event:${eventSlug || "manual"}:${action.id || action._timestamp}`;
+      const orderDate = new Date(action._timestamp || 0);
+
+      const orderAction = inheritTimestamp({
+        ...new_order({
+          orderID,
+          email: "live-event",
+          product: eventName,
+          date: orderDate,
+        }),
+        _ephemeral: true,
+      });
+      nextState = {
+        ...nextState,
+        inventory: inventory(nextState.inventory, orderAction),
+      };
+      logger(orderAction, nextState, action._timestamp);
+
+      lines.forEach((line) => {
+        const packageAction = inheritTimestamp({
+          ...package_item({
+            orderID,
+            itemKey: line.itemKey as any,
+            qty: line.qty,
+          }),
+          _ephemeral: true,
+        });
+        nextState = {
+          ...nextState,
+          inventory: inventory(nextState.inventory, packageAction),
+        };
+        logger(packageAction, nextState, action._timestamp);
+      });
+    }
+
+    if (indices.length > 0) {
+      const markAction = inheritTimestamp(markLiveEventRowsDone({ indices }));
+      nextState = {
+        ...nextState,
+        liveEventImport: liveEventImport(nextState.liveEventImport, markAction),
+      };
+      logger(markAction, nextState, action._timestamp);
     }
   }
 

--- a/src/routes/live-event-import/+page.svelte
+++ b/src/routes/live-event-import/+page.svelte
@@ -10,10 +10,9 @@
     set_all_approvals,
     clear_import,
     commit_import,
+    findLiveEventInventoryMatch,
     type LiveEventRawRow,
-    type LiveEventImportItem,
   } from "$lib/live-event-import-slice";
-  import { makeInventoryItemKey } from "$lib/sku";
 
   let localPaste = "";
   let statusMessage = "";
@@ -22,31 +21,6 @@
   $: importState = $store.liveEventImport;
   $: rows = (importState.rows || []) as LiveEventRawRow[];
   $: localPaste = importState.rawPaste || localPaste;
-
-  const trim = (value: unknown) =>
-    typeof value === "string" ? value.trim() : "";
-
-  function findInventoryMatch(item: LiveEventImportItem): {
-    key: string;
-    item: any;
-    matchType: "exact" | "jan";
-  } | null {
-    const exactKey = makeInventoryItemKey(item.janCode, item.subtype);
-    const exact = $store.inventory.idToItem[exactKey];
-    if (exact) return { key: exactKey, item: exact, matchType: "exact" };
-
-    const janMatches = Object.entries($store.inventory.idToItem)
-      .filter(([, inventoryItem]: [string, any]) => {
-        return trim(inventoryItem?.janCode) === item.janCode;
-      })
-      .map(([key, inventoryItem]) => ({ key, item: inventoryItem }));
-
-    if (janMatches.length === 1) {
-      return { ...janMatches[0], matchType: "jan" };
-    }
-
-    return null;
-  }
 
   function available(item: any): number {
     return Number(item?.qty || 0) - Number(item?.shipped || 0);
@@ -58,7 +32,10 @@
       return { status: row.error || "Skipped", className: "error" };
     }
 
-    const match = findInventoryMatch(row.parsed);
+    const match = findLiveEventInventoryMatch(
+      row.parsed,
+      $store.inventory.idToItem,
+    );
     if (!match) return { status: "Missing item", className: "error" };
 
     const currentAvailable = available(match.item);
@@ -85,7 +62,7 @@
   $: readyRows = rows.filter((row: LiveEventRawRow) => {
     if (!row.approved || row.processed || row.error || !row.parsed)
       return false;
-    return !!findInventoryMatch(row.parsed);
+    return !!findLiveEventInventoryMatch(row.parsed, $store.inventory.idToItem);
   });
   $: approvedSoldCount = readyRows.reduce(
     (sum: number, row: LiveEventRawRow) => sum + Number(row.parsed?.sold || 0),

--- a/src/routes/live-event-import/+page.svelte
+++ b/src/routes/live-event-import/+page.svelte
@@ -1,0 +1,506 @@
+<script lang="ts">
+  import { store } from "$lib/store";
+  import { user } from "$lib/user-store";
+  import { firestore } from "$lib/firebase";
+  import { broadcast } from "$lib/redux-firestore";
+  import ImageThumbnail from "$lib/components/ImageThumbnail.svelte";
+  import {
+    set_paste,
+    toggle_row_approval,
+    set_all_approvals,
+    clear_import,
+    commit_import,
+    type LiveEventRawRow,
+    type LiveEventImportItem,
+  } from "$lib/live-event-import-slice";
+  import { makeInventoryItemKey } from "$lib/sku";
+
+  let localPaste = "";
+  let statusMessage = "";
+  let rows: LiveEventRawRow[] = [];
+
+  $: importState = $store.liveEventImport;
+  $: rows = (importState.rows || []) as LiveEventRawRow[];
+  $: localPaste = importState.rawPaste || localPaste;
+
+  const trim = (value: unknown) =>
+    typeof value === "string" ? value.trim() : "";
+
+  function findInventoryMatch(item: LiveEventImportItem): {
+    key: string;
+    item: any;
+    matchType: "exact" | "jan";
+  } | null {
+    const exactKey = makeInventoryItemKey(item.janCode, item.subtype);
+    const exact = $store.inventory.idToItem[exactKey];
+    if (exact) return { key: exactKey, item: exact, matchType: "exact" };
+
+    const janMatches = Object.entries($store.inventory.idToItem)
+      .filter(([, inventoryItem]: [string, any]) => {
+        return trim(inventoryItem?.janCode) === item.janCode;
+      })
+      .map(([key, inventoryItem]) => ({ key, item: inventoryItem }));
+
+    if (janMatches.length === 1) {
+      return { ...janMatches[0], matchType: "jan" };
+    }
+
+    return null;
+  }
+
+  function available(item: any): number {
+    return Number(item?.qty || 0) - Number(item?.shipped || 0);
+  }
+
+  function rowAnalysis(row: LiveEventRawRow) {
+    if (row.processed) return { status: "Done", className: "done" };
+    if (row.error || !row.parsed) {
+      return { status: row.error || "Skipped", className: "error" };
+    }
+
+    const match = findInventoryMatch(row.parsed);
+    if (!match) return { status: "Missing item", className: "error" };
+
+    const currentAvailable = available(match.item);
+    const projected = currentAvailable - row.parsed.sold;
+    if (projected < 0) {
+      return {
+        status: "Oversold",
+        className: "warning",
+        match,
+        currentAvailable,
+        projected,
+      };
+    }
+
+    return {
+      status: row.parsed.sold > 0 ? "Ready" : "No sale",
+      className: row.parsed.sold > 0 ? "ready" : "muted",
+      match,
+      currentAvailable,
+      projected,
+    };
+  }
+
+  $: readyRows = rows.filter((row: LiveEventRawRow) => {
+    if (!row.approved || row.processed || row.error || !row.parsed)
+      return false;
+    return !!findInventoryMatch(row.parsed);
+  });
+  $: approvedSoldCount = readyRows.reduce(
+    (sum: number, row: LiveEventRawRow) => sum + Number(row.parsed?.sold || 0),
+    0,
+  );
+  $: totalSoldCount = rows.reduce(
+    (sum: number, row: LiveEventRawRow) => sum + Number(row.parsed?.sold || 0),
+    0,
+  );
+  $: approvedRowCount = readyRows.length;
+  $: errorCount = rows.filter((row: LiveEventRawRow) => {
+    const analysis = rowAnalysis(row);
+    return analysis.className === "error";
+  }).length;
+  $: doneCount = rows.filter((row: LiveEventRawRow) => row.processed).length;
+
+  function broadcastAction(action: any) {
+    if (!$user?.uid) {
+      statusMessage = "Sign in before saving changes.";
+      return;
+    }
+    broadcast(firestore, $user.uid, action);
+  }
+
+  function applyPaste(rawPaste = localPaste) {
+    statusMessage = "";
+    broadcastAction(set_paste({ rawPaste }));
+  }
+
+  function handlePaste(event: ClipboardEvent) {
+    const text = event.clipboardData?.getData("text/plain");
+    if (!text) return;
+    event.preventDefault();
+    localPaste = text;
+    applyPaste(text);
+  }
+
+  function toggleApproval(index: number, approved: boolean) {
+    broadcastAction(toggle_row_approval({ index, approved }));
+  }
+
+  function approveAll(approved: boolean) {
+    broadcastAction(set_all_approvals({ approved }));
+  }
+
+  function clearImport() {
+    localPaste = "";
+    statusMessage = "";
+    broadcastAction(clear_import());
+  }
+
+  function commitSales() {
+    statusMessage = "";
+    broadcastAction(commit_import());
+    statusMessage = "Approved sales committed.";
+  }
+</script>
+
+<svelte:head>
+  <title>Live Event Import</title>
+</svelte:head>
+
+<section class="page">
+  <header class="toolbar">
+    <div>
+      <h1>Live Event Import</h1>
+      <div class="meta">
+        {#if importState.eventName}
+          {importState.eventName}
+        {:else}
+          Manual event
+        {/if}
+        · {rows.length} rows · {totalSoldCount} sold
+      </div>
+    </div>
+
+    <div class="actions">
+      <button type="button" on:click={() => approveAll(true)}>
+        Approve all
+      </button>
+      <button type="button" on:click={() => approveAll(false)}>
+        Unapprove all
+      </button>
+      <button type="button" class="secondary" on:click={clearImport}>
+        Clear
+      </button>
+      <button
+        type="button"
+        class="primary"
+        disabled={approvedRowCount === 0}
+        on:click={commitSales}
+      >
+        Commit {approvedSoldCount} sales
+      </button>
+    </div>
+  </header>
+
+  <div class="summary">
+    <div>
+      <strong>{approvedRowCount}</strong>
+      <span>approved rows</span>
+    </div>
+    <div>
+      <strong>{doneCount}</strong>
+      <span>committed rows</span>
+    </div>
+    <div class:error={errorCount > 0}>
+      <strong>{errorCount}</strong>
+      <span>needs attention</span>
+    </div>
+  </div>
+
+  <div class="paste-panel">
+    <label for="live-event-paste">Paste TSV or CSV</label>
+    <textarea
+      id="live-event-paste"
+      bind:value={localPaste}
+      on:paste={handlePaste}
+      on:change={() => applyPaste()}
+      spellcheck="false"
+      placeholder="janCode, subtype, description, taking, returned, sold"
+    />
+    <button type="button" on:click={() => applyPaste()}>Parse paste</button>
+  </div>
+
+  {#if statusMessage}
+    <div class="status">{statusMessage}</div>
+  {/if}
+
+  {#if rows.length > 0}
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>Approve</th>
+            <th>Status</th>
+            <th>Image</th>
+            <th>JAN</th>
+            <th>Subtype</th>
+            <th>Description</th>
+            <th class="number">System</th>
+            <th class="number">Office</th>
+            <th class="number">Taken</th>
+            <th class="number">Returned</th>
+            <th class="number">Sold</th>
+            <th class="number">Available</th>
+            <th class="number">After</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each rows as row, index}
+            {@const analysis = rowAnalysis(row)}
+            <tr class={analysis.className}>
+              <td>
+                <input
+                  type="checkbox"
+                  checked={row.approved}
+                  disabled={!!row.error || row.processed}
+                  on:change={(event) =>
+                    toggleApproval(index, event.currentTarget.checked)}
+                />
+              </td>
+              <td>
+                <span class="pill">{analysis.status}</span>
+                {#if row.warnings?.length}
+                  <div class="warning-text">{row.warnings.join(" ")}</div>
+                {/if}
+              </td>
+              <td>
+                {#if row.parsed?.image}
+                  <div class="thumb">
+                    <ImageThumbnail
+                      src={row.parsed.image}
+                      alt={row.parsed.description}
+                      width="48px"
+                      height="48px"
+                      fit="contain"
+                    />
+                  </div>
+                {/if}
+              </td>
+              <td>{row.parsed?.janCode || ""}</td>
+              <td>{row.parsed?.subtype || "Default"}</td>
+              <td class="description">{row.parsed?.description || row.error}</td
+              >
+              <td class="number">{row.parsed?.systemCount ?? ""}</td>
+              <td class="number">{row.parsed?.actualOfficeCount ?? ""}</td>
+              <td class="number">{row.parsed?.taking ?? ""}</td>
+              <td class="number">{row.parsed?.returned ?? ""}</td>
+              <td class="number sold">{row.parsed?.sold ?? ""}</td>
+              <td class="number">{analysis.currentAvailable ?? ""}</td>
+              <td class="number">{analysis.projected ?? ""}</td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </div>
+  {/if}
+</section>
+
+<style>
+  .page {
+    padding: 24px;
+    max-width: 1600px;
+    margin: 0 auto;
+  }
+
+  .toolbar {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    align-items: flex-start;
+    margin-bottom: 16px;
+  }
+
+  h1 {
+    margin: 0;
+    font-size: 1.75rem;
+  }
+
+  .meta {
+    color: #58606f;
+    margin-top: 4px;
+  }
+
+  .actions {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+
+  button {
+    border: 1px solid #c8ced8;
+    background: #fff;
+    border-radius: 6px;
+    padding: 8px 12px;
+    cursor: pointer;
+    font-weight: 600;
+  }
+
+  button:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+
+  .primary {
+    background: #1f6f52;
+    color: white;
+    border-color: #1f6f52;
+  }
+
+  .secondary {
+    color: #6b2530;
+  }
+
+  .summary {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(120px, 1fr));
+    gap: 1px;
+    border: 1px solid #d8dee8;
+    border-radius: 8px;
+    overflow: hidden;
+    margin-bottom: 16px;
+    max-width: 640px;
+  }
+
+  .summary > div {
+    background: #f7f9fb;
+    padding: 12px;
+  }
+
+  .summary strong {
+    display: block;
+    font-size: 1.4rem;
+  }
+
+  .summary span {
+    color: #596273;
+    font-size: 0.85rem;
+  }
+
+  .summary .error strong {
+    color: #9a3412;
+  }
+
+  .paste-panel {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 8px;
+    align-items: end;
+    margin-bottom: 16px;
+  }
+
+  .paste-panel label {
+    grid-column: 1 / -1;
+    font-weight: 700;
+  }
+
+  textarea {
+    min-height: 130px;
+    resize: vertical;
+    font-family:
+      ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+      monospace;
+    border: 1px solid #c8ced8;
+    border-radius: 8px;
+    padding: 12px;
+    font-size: 0.9rem;
+  }
+
+  .status {
+    margin-bottom: 12px;
+    color: #1f6f52;
+    font-weight: 600;
+  }
+
+  .table-wrap {
+    overflow: auto;
+    border: 1px solid #d8dee8;
+    border-radius: 8px;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 1180px;
+  }
+
+  th,
+  td {
+    padding: 8px;
+    border-bottom: 1px solid #e5e9f0;
+    text-align: left;
+    vertical-align: middle;
+    font-size: 0.9rem;
+  }
+
+  th {
+    position: sticky;
+    top: 0;
+    background: #f4f6f9;
+    z-index: 1;
+  }
+
+  tr.done {
+    color: #697386;
+    background: #f8fafc;
+  }
+
+  tr.error {
+    background: #fff7ed;
+  }
+
+  tr.warning {
+    background: #fffbeb;
+  }
+
+  .number {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .sold {
+    font-weight: 700;
+  }
+
+  .description {
+    min-width: 260px;
+    max-width: 420px;
+  }
+
+  .thumb {
+    width: 48px;
+    height: 48px;
+  }
+
+  .pill {
+    display: inline-block;
+    min-width: 72px;
+    border-radius: 999px;
+    background: #edf2f7;
+    padding: 4px 8px;
+    text-align: center;
+    font-size: 0.8rem;
+    font-weight: 700;
+  }
+
+  .warning-text {
+    color: #9a3412;
+    font-size: 0.78rem;
+    margin-top: 4px;
+    max-width: 280px;
+  }
+
+  @media (max-width: 820px) {
+    .page {
+      padding: 16px;
+    }
+
+    .toolbar {
+      display: block;
+    }
+
+    .actions {
+      justify-content: flex-start;
+      margin-top: 12px;
+    }
+
+    .summary {
+      grid-template-columns: 1fr;
+    }
+
+    .paste-panel {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/tests/unit/live-event-import-slice.test.ts
+++ b/tests/unit/live-event-import-slice.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import {
+  commit_import,
+  computeLiveEventImportCommit,
+  parseLiveEventPaste,
+  set_paste,
+} from "../../src/lib/live-event-import-slice";
+import { bulk_import_items } from "../../src/lib/inventory";
+import { rootReducer } from "../../src/lib/root-reducer";
+import { makeInventoryItemKey } from "../../src/lib/sku";
+
+const timestamp = { seconds: 1_700_000_000, nanoseconds: 0 };
+
+describe("live event import", () => {
+  it("parses TSV rows and infers the event name from taking/returned columns", () => {
+    const paste = [
+      [
+        "janCode",
+        "subtype",
+        "description",
+        "image",
+        "hsCode",
+        "qty",
+        "pieces",
+        "shipped",
+        "Inventory Count per system",
+        "Actual inventory count in office",
+        "Taking to Christmas Market",
+        "Returned from Christmas Market",
+        "Sold",
+      ].join("\t"),
+      [
+        "4510085333840",
+        "Default",
+        "Senshu Kawaii Panda Wall Stickers",
+        "https://example.test/panda.jpg",
+        "48211010",
+        "20",
+        "1",
+        "0",
+        "20",
+        "20",
+        "10",
+        "8",
+        "2",
+      ].join("\t"),
+    ].join("\n");
+
+    const parsed = parseLiveEventPaste(paste);
+
+    expect(parsed.delimiter).toBe("tsv");
+    expect(parsed.eventName).toBe("Christmas Market");
+    expect(parsed.rows).toHaveLength(1);
+    expect(parsed.rows[0].approved).toBe(true);
+    expect(parsed.rows[0].parsed?.janCode).toBe("4510085333840");
+    expect(parsed.rows[0].parsed?.subtype).toBe("Default");
+    expect(parsed.rows[0].parsed?.sold).toBe(2);
+  });
+
+  it("derives sold from taken minus returned when Sold is absent", () => {
+    const paste = [
+      "janCode,subtype,description,Taking to Pop Up,Returned from Pop Up",
+      "4510085335639,Yellow,Notebook,8,2",
+    ].join("\n");
+
+    const parsed = parseLiveEventPaste(paste);
+
+    expect(parsed.eventName).toBe("Pop Up");
+    expect(parsed.rows[0].parsed?.sold).toBe(6);
+  });
+
+  it("computes commit lines from approved parsed rows and exact inventory keys", () => {
+    const key = makeInventoryItemKey("4510085335639", "Yellow");
+    const parsed = parseLiveEventPaste(
+      [
+        "janCode,subtype,description,Sold",
+        "4510085335639,Yellow,Notebook,6",
+      ].join("\n"),
+    );
+
+    const result = computeLiveEventImportCommit(
+      {
+        rawPaste: "",
+        delimiter: "csv",
+        eventName: "market",
+        step: "review",
+        rows: parsed.rows,
+      },
+      {
+        [key]: {
+          janCode: "4510085335639",
+          subtype: "Yellow",
+          qty: 10,
+          shipped: 0,
+        },
+      },
+    );
+
+    expect(result.lines).toEqual([{ index: 0, itemKey: key, qty: 6 }]);
+    expect(result.indices).toEqual([0]);
+  });
+
+  it("commits approved sales through package_item synthesis", () => {
+    const key = makeInventoryItemKey("4510085335639", "Yellow");
+    const paste = [
+      "janCode,subtype,description,Taking to Christmas Market,Returned from Christmas Market,Sold",
+      "4510085335639,Yellow,Notebook,8,2,6",
+    ].join("\n");
+    const logger = () => {};
+
+    let state = rootReducer(undefined, { type: "@@INIT" }, logger);
+    state = rootReducer(
+      state,
+      {
+        ...bulk_import_items({
+          items: [
+            {
+              type: "new",
+              id: key,
+              item: {
+                janCode: "4510085335639",
+                subtype: "Yellow",
+                description: "Notebook",
+                hsCode: "",
+                image: "",
+                qty: 10,
+                pieces: 1,
+                shipped: 0,
+                creationDate: "Test",
+                timestamp: 0,
+              },
+            },
+          ],
+        }),
+        id: "seed",
+        timestamp,
+      },
+      logger,
+    );
+
+    state = rootReducer(
+      state,
+      { ...set_paste({ rawPaste: paste }), id: "paste", timestamp },
+      logger,
+    );
+    state = rootReducer(
+      state,
+      { ...commit_import(), id: "commit-1", timestamp },
+      logger,
+    );
+
+    expect(state.inventory.idToItem[key].shipped).toBe(6);
+    expect(state.liveEventImport.rows[0].processed).toBe(true);
+    expect(
+      state.inventory.orderIdToOrder["live-event:christmas-market:commit-1"]
+        .items,
+    ).toEqual([{ itemKey: key, qty: 6 }]);
+  });
+});

--- a/tests/unit/live-event-import-slice.test.ts
+++ b/tests/unit/live-event-import-slice.test.ts
@@ -100,6 +100,65 @@ describe("live event import", () => {
     expect(result.indices).toEqual([0]);
   });
 
+  it("does not fall back to a different subtype for the same JAN", () => {
+    const greenKey = makeInventoryItemKey("4510085335639", "Green");
+    const parsed = parseLiveEventPaste(
+      [
+        "janCode,subtype,description,Sold",
+        "4510085335639,Yellow,Notebook,6",
+      ].join("\n"),
+    );
+
+    const result = computeLiveEventImportCommit(
+      {
+        rawPaste: "",
+        delimiter: "csv",
+        eventName: "market",
+        step: "review",
+        rows: parsed.rows,
+      },
+      {
+        [greenKey]: {
+          janCode: "4510085335639",
+          subtype: "Green",
+          qty: 10,
+          shipped: 0,
+        },
+      },
+    );
+
+    expect(result.lines).toEqual([]);
+    expect(result.indices).toEqual([]);
+  });
+
+  it("does not infer a non-default subtype when the paste has no subtype", () => {
+    const yellowKey = makeInventoryItemKey("4510085335639", "Yellow");
+    const parsed = parseLiveEventPaste(
+      ["janCode,description,Sold", "4510085335639,Notebook,6"].join("\n"),
+    );
+
+    const result = computeLiveEventImportCommit(
+      {
+        rawPaste: "",
+        delimiter: "csv",
+        eventName: "market",
+        step: "review",
+        rows: parsed.rows,
+      },
+      {
+        [yellowKey]: {
+          janCode: "4510085335639",
+          subtype: "Yellow",
+          qty: 10,
+          shipped: 0,
+        },
+      },
+    );
+
+    expect(result.lines).toEqual([]);
+    expect(result.indices).toEqual([]);
+  });
+
   it("commits approved sales through package_item synthesis", () => {
     const key = makeInventoryItemKey("4510085335639", "Yellow");
     const paste = [


### PR DESCRIPTION
## What changed

Adds a manual live-event sales import workflow at `/live-event-import`.

- Added `docs/design/LIVE_EVENT_SALES_IMPORT_DESIGN.md` describing the raw-paste fact model and reducer-derived commit flow.
- Added `liveEventImport` Redux state for pasted TSV/CSV, parsed review rows, approvals, warnings, and done markers.
- Wired `liveEventImport/commit_import` in the root reducer to synthesize normal `new_order` and `package_item` actions from approved rows.
- Added the interactive review/approval page and navigation entry.
- Added unit coverage for parsing, derived sold quantities, commit planning, and root reducer commit behavior.

## Why

Live-event sales are counted from pasted spreadsheet data, so the paste should remain the durable source fact. Reducers derive row interpretation and inventory impact, matching the existing import architecture.

## Validation

- `npm exec -- vitest run tests/unit/live-event-import-slice.test.ts`
- `npm run check`
- `npm run lint`
- pre-commit hook: full `CI=1 vitest run --coverage`
- pre-push hook: live fixture health check, live Vitest suite, live E2E suite, non-live E2E suite
