### PR TITLE
fix(listing-detail): dispatch subtype LAST in onConfirmAddVariant

### DIFF
--- a/src/routes/listing-detail/+page.svelte
+++ b/src/routes/listing-detail/+page.svelte
@@ -1684,18 +1684,10 @@
           to: handle,
         }),
       );
-      // 3. Sync Subtype
-      if (subtype && subtype !== item.subtype) {
-        dispatchBroadcast(
-          update_field({
-            id: itemId,
-            field: "subtype",
-            from: item.subtype || "",
-            to: subtype,
-          }),
-        );
-      }
-      // 4. Sync Qty (for the new item itself)
+      // 3. Sync Qty (for the new item itself) — must happen BEFORE subtype,
+      // because the subtype update re-keys idToItem and any subsequent
+      // action against itemId silently no-ops. Same discipline as
+      // confirm_proposal in src/lib/root-reducer.ts.
       if (typeof qty === "number" && qty !== item.qty) {
         dispatchBroadcast(
           update_field({
@@ -1703,6 +1695,17 @@
             field: "qty",
             from: item.qty,
             to: qty,
+          }),
+        );
+      }
+      // 4. Sync Subtype LAST (triggers the rename).
+      if (subtype && subtype !== item.subtype) {
+        dispatchBroadcast(
+          update_field({
+            id: itemId,
+            field: "subtype",
+            from: item.subtype || "",
+            to: subtype,
           }),
         );
       }

--- a/tests/unit/add-variant-dispatch-order.test.ts
+++ b/tests/unit/add-variant-dispatch-order.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+
+import { rootReducer } from "$lib/root-reducer";
+import { update_field, update_item, type Item } from "$lib/inventory";
+
+// onConfirmAddVariant in src/routes/listing-detail/+page.svelte's live-mode
+// branch dispatches three update_field actions against the same itemId. When
+// itemId is a bare JAN row and the burst includes a subtype change, the
+// subtype update re-keys the inventory item and any *later* action against
+// the original itemId silently no-ops (see audit row 15, 2026-03-29 burst on
+// `4542804123579`).
+//
+// This test verifies that placing qty before subtype in the burst keeps the
+// qty edit on the canonical key, and that the inverse order silently drops
+// it. Acts on rootReducer directly so it stays fast and self-contained.
+
+const JAN = "4542804123579";
+const NEW_HANDLE =
+  "amifa-masterpiece-collection-a4-collage-paper-8-15-4542804123555";
+const NEW_SUBTYPE = "Transparent";
+const SEED_QTY = 24;
+const NEW_QTY = 12;
+
+const seedItem: Item = {
+  janCode: JAN,
+  subtype: "",
+  description: "Amifa Masterpiece Collection",
+  hsCode: "48114190",
+  image: "",
+  qty: SEED_QTY,
+  pieces: 1,
+  shipped: 0,
+  creationDate: "Jan 1, 2026",
+  timestamp: 0,
+};
+
+function seedState() {
+  let state = rootReducer(undefined, { type: "@@INIT" });
+  state = rootReducer(state, update_item({ id: JAN, item: seedItem }) as any);
+  return state;
+}
+
+function qtyOnCanonical(state: any) {
+  return state.inventory.idToItem[`${JAN}${NEW_SUBTYPE}`]?.qty;
+}
+
+function bareStillExists(state: any) {
+  return !!state.inventory.idToItem[JAN];
+}
+
+describe("onConfirmAddVariant dispatch ordering", () => {
+  it("regression baseline: handle → subtype → qty drops the qty edit", () => {
+    let state = seedState();
+    expect(state.inventory.idToItem[JAN]?.qty).toBe(SEED_QTY);
+
+    // Original (broken) order.
+    state = rootReducer(
+      state,
+      update_field({
+        id: JAN,
+        field: "handle",
+        from: "",
+        to: NEW_HANDLE,
+      }) as any,
+    );
+    state = rootReducer(
+      state,
+      update_field({
+        id: JAN,
+        field: "subtype",
+        from: "",
+        to: NEW_SUBTYPE,
+      }) as any,
+    );
+    state = rootReducer(
+      state,
+      update_field({
+        id: JAN,
+        field: "qty",
+        from: SEED_QTY,
+        to: NEW_QTY,
+      }) as any,
+    );
+
+    expect(bareStillExists(state)).toBe(false);
+    // Bug: qty edit silently no-ops because the subtype update already
+    // re-keyed the item away from the bare JAN.
+    expect(qtyOnCanonical(state)).toBe(SEED_QTY);
+  });
+
+  it("with the fix: handle → qty → subtype lands the qty on the renamed key", () => {
+    let state = seedState();
+
+    // Fixed order: subtype LAST so the re-key happens after qty.
+    state = rootReducer(
+      state,
+      update_field({
+        id: JAN,
+        field: "handle",
+        from: "",
+        to: NEW_HANDLE,
+      }) as any,
+    );
+    state = rootReducer(
+      state,
+      update_field({
+        id: JAN,
+        field: "qty",
+        from: SEED_QTY,
+        to: NEW_QTY,
+      }) as any,
+    );
+    state = rootReducer(
+      state,
+      update_field({
+        id: JAN,
+        field: "subtype",
+        from: "",
+        to: NEW_SUBTYPE,
+      }) as any,
+    );
+
+    expect(bareStillExists(state)).toBe(false);
+    expect(qtyOnCanonical(state)).toBe(NEW_QTY);
+  });
+});


### PR DESCRIPTION
## Summary

Forward-looking fix for audit row 15 in `docs/investigations/GHOST_MISSING_15_AUDIT.md`. The live-mode "manage / add variant" save in `src/routes/listing-detail/+page.svelte` fires three `update_field` actions against the same `itemId` in handle → subtype → qty order. The subtype update re-keys `idToItem` (via the `update_field` reducer's subtype branch), so the qty action that follows targets a now-stale id and is silently dropped (`Skipping update_field for missing item`).

The production action burst on 2026-03-29 for `4542804123579` — three actions within 95 ms, qty=24 → 12 silently lost — is exactly this code path.

Patch reorders the dispatches so subtype fires LAST, matching the discipline already documented in `confirm_proposal` (`src/lib/root-reducer.ts:1867` — "Update Subtype LAST because it triggers a rename").

## Scope

- Pure UI dispatch-order change.
- Does NOT remediate the existing 2026-03-29 divergence (operator error, intent ambiguous — won't fix per discussion).
- Does NOT touch `rootReducer`. Apr 25 backup replay produces byte-identical state to main.

## Test plan

- [x] `tests/unit/add-variant-dispatch-order.test.ts` — synthesized 3-action burst through `rootReducer`. Two cases:
  - Pre-fix order (handle → subtype → qty): qty silently no-ops on the rename target. This is the regression baseline.
  - Post-fix order (handle → qty → subtype): qty lands on the renamed canonical key.
- [x] `tests/unit/ghost-shipped-counter-replay.test.ts` (PR #119's full-backup replay) — still passes with identical Swan/Strawberry/Cherry shipped values, confirming zero reducer impact.
- [x] `tests/unit/shabby-chic-shipped-replay.test.ts` — passes (no regression in other replay coverage).
- [x] `bun run scripts/assess-ghost-fix-impact.ts` — produces identical 3-key delta to main.
- [x] `bun run check` — clean.
- [x] Pre-push hook (live fixtures + non-live E2E, 26 Playwright specs) — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)