### PR TITLE
fix(listing-creation): canonicalize proposal handle at the reducer boundary

### DIFF
--- a/scripts/handle-slugify-blast-radius.ts
+++ b/scripts/handle-slugify-blast-radius.ts
@@ -1,0 +1,208 @@
+// Capture the relevant slices of the final replay state for the
+// proposal-handle slugification fix. Intended to be run twice — once
+// with the patched reducer on the branch (fixed) and once with main
+// (unfixed) — then diff the two output files.
+//
+// Usage:
+//   bun run scripts/handle-slugify-blast-radius.ts /tmp/handles-after.json
+//
+// Then on main:
+//   git stash
+//   bun run scripts/handle-slugify-blast-radius.ts /tmp/handles-before.json
+//   git stash pop
+//
+// And diff with:
+//   bun run scripts/handle-slugify-blast-radius.ts --diff \
+//     /tmp/handles-before.json /tmp/handles-after.json
+
+import { readFileSync, writeFileSync } from "fs";
+import { rootReducer } from "../src/lib/root-reducer";
+
+const BACKUP =
+  "/Users/anicolao/projects/antigravity/production-backup-apr-25/firestore-export.json";
+
+function tsKey(a: any): number {
+  const ts = a?.timestamp;
+  if (typeof ts?._seconds === "number")
+    return ts._seconds * 1_000_000_000 + (Number(ts._nanoseconds) || 0);
+  if (typeof ts?.seconds === "number")
+    return ts.seconds * 1_000_000_000 + (Number(ts.nanoseconds) || 0);
+  return 0;
+}
+
+interface Snapshot {
+  proposalsHandle: Record<string, string>; // janCode -> proposal.handle
+  proposalsTitle: Record<string, string>; // janCode -> proposal.title (context)
+  inventoryHandle: Record<string, string>; // itemKey -> idToItem[itemKey].handle
+  idToHandle: Record<string, string>; // itemKey -> listings.idToHandle[itemKey]
+  handleToListingKeys: string[]; // sorted keys of listings.handleToListing
+}
+
+function captureSnapshot(state: any): Snapshot {
+  const proposals = state?.listingCreation?.proposals || {};
+  const proposalsHandle: Record<string, string> = {};
+  const proposalsTitle: Record<string, string> = {};
+  for (const jan of Object.keys(proposals)) {
+    proposalsHandle[jan] = proposals[jan].handle || "";
+    proposalsTitle[jan] = proposals[jan].title || "";
+  }
+  const inv = state?.inventory?.idToItem || {};
+  const inventoryHandle: Record<string, string> = {};
+  for (const k of Object.keys(inv)) {
+    if (inv[k]?.handle) inventoryHandle[k] = inv[k].handle;
+  }
+  const id2h = state?.listings?.idToHandle || {};
+  const idToHandle: Record<string, string> = {};
+  for (const k of Object.keys(id2h)) idToHandle[k] = id2h[k];
+  const h2l = state?.listings?.handleToListing || {};
+  const handleToListingKeys = Object.keys(h2l).sort();
+  return {
+    proposalsHandle,
+    proposalsTitle,
+    inventoryHandle,
+    idToHandle,
+    handleToListingKeys,
+  };
+}
+
+function diffMaps(
+  label: string,
+  before: Record<string, string>,
+  after: Record<string, string>,
+): string[] {
+  const lines: string[] = [];
+  const keys = new Set([...Object.keys(before), ...Object.keys(after)]);
+  for (const k of [...keys].sort()) {
+    const b = before[k] ?? "<absent>";
+    const a = after[k] ?? "<absent>";
+    if (b !== a) {
+      lines.push(`  ${label}[${JSON.stringify(k)}]`);
+      lines.push(`    before: ${JSON.stringify(b)}`);
+      lines.push(`    after:  ${JSON.stringify(a)}`);
+    }
+  }
+  return lines;
+}
+
+function diffSets(
+  label: string,
+  before: string[],
+  after: string[],
+): string[] {
+  const bSet = new Set(before);
+  const aSet = new Set(after);
+  const onlyBefore = [...bSet].filter((k) => !aSet.has(k)).sort();
+  const onlyAfter = [...aSet].filter((k) => !bSet.has(k)).sort();
+  const lines: string[] = [];
+  if (onlyBefore.length || onlyAfter.length) {
+    lines.push(`  ${label}:`);
+    for (const k of onlyBefore) lines.push(`    - ${JSON.stringify(k)}  (only in BEFORE)`);
+    for (const k of onlyAfter) lines.push(`    + ${JSON.stringify(k)}  (only in AFTER)`);
+  }
+  return lines;
+}
+
+function run() {
+  const args = process.argv.slice(2);
+
+  // Diff mode
+  if (args[0] === "--diff") {
+    const beforePath = args[1];
+    const afterPath = args[2];
+    if (!beforePath || !afterPath) {
+      console.error(
+        "Usage: --diff <before.json> <after.json>",
+      );
+      process.exit(1);
+    }
+    const before = JSON.parse(readFileSync(beforePath, "utf-8")) as Snapshot;
+    const after = JSON.parse(readFileSync(afterPath, "utf-8")) as Snapshot;
+
+    console.log(`# Blast-radius diff: ${beforePath} -> ${afterPath}\n`);
+
+    const propLines = diffMaps(
+      "listingCreation.proposals.handle",
+      before.proposalsHandle,
+      after.proposalsHandle,
+    );
+    console.log(`## proposals[*].handle  (${propLines.length / 3} changed)`);
+    if (propLines.length === 0) console.log("  (no change)");
+    else console.log(propLines.join("\n"));
+
+    const invLines = diffMaps(
+      "inventory.idToItem[*].handle",
+      before.inventoryHandle,
+      after.inventoryHandle,
+    );
+    console.log(
+      `\n## inventory.idToItem[*].handle  (${invLines.length / 3} changed)`,
+    );
+    if (invLines.length === 0) console.log("  (no change)");
+    else console.log(invLines.join("\n"));
+
+    const id2hLines = diffMaps(
+      "listings.idToHandle",
+      before.idToHandle,
+      after.idToHandle,
+    );
+    console.log(
+      `\n## listings.idToHandle  (${id2hLines.length / 3} changed)`,
+    );
+    if (id2hLines.length === 0) console.log("  (no change)");
+    else console.log(id2hLines.join("\n"));
+
+    const h2lLines = diffSets(
+      "listings.handleToListing keys",
+      before.handleToListingKeys,
+      after.handleToListingKeys,
+    );
+    console.log(`\n## listings.handleToListing key set`);
+    if (h2lLines.length === 0) console.log("  (no change)");
+    else console.log(h2lLines.join("\n"));
+
+    // Quick summary
+    const changeBuckets = {
+      proposals: propLines.length / 3,
+      inventory: invLines.length / 3,
+      idToHandle: id2hLines.length / 3,
+      h2lKeys:
+        (h2lLines.length > 0 ? h2lLines.length - 1 : 0), // minus the header line
+    };
+    console.log(
+      `\n## Summary: ${JSON.stringify(changeBuckets)}`,
+    );
+    return;
+  }
+
+  // Capture mode
+  const outPath = args[0] || "/tmp/handles-snapshot.json";
+  console.error(`Replaying ${BACKUP} ...`);
+  const raw = readFileSync(BACKUP, "utf-8");
+  const docs = JSON.parse(raw).collections.broadcast.documents;
+  const actions = docs
+    .map((d: any) => ({ id: d.id, ...d.data }))
+    .sort((a: any, b: any) => tsKey(a) - tsKey(b));
+
+  let state: any = rootReducer(undefined, { type: "@@INIT" });
+  for (let i = 0; i < actions.length; i++) {
+    try {
+      state = rootReducer(state, actions[i] as any, () => {});
+    } catch {
+      /* mirror audit-page tolerance */
+    }
+    if ((i + 1) % 5000 === 0) console.error(`  ${i + 1}/${actions.length}`);
+  }
+  console.error(`Replay finished.`);
+
+  const snap = captureSnapshot(state);
+  writeFileSync(outPath, JSON.stringify(snap, null, 2));
+  console.error(`Wrote ${outPath}`);
+  console.error(
+    `proposals: ${Object.keys(snap.proposalsHandle).length}, ` +
+      `inventory rows with handle: ${Object.keys(snap.inventoryHandle).length}, ` +
+      `idToHandle: ${Object.keys(snap.idToHandle).length}, ` +
+      `handleToListing keys: ${snap.handleToListingKeys.length}`,
+  );
+}
+
+run();

--- a/src/lib/handle-utils.ts
+++ b/src/lib/handle-utils.ts
@@ -3,14 +3,53 @@
  * Format: slugified-title-jancode
  */
 export function generateHandle(title: string, jan: string): string {
-  const slug = title
+  return `${slugifyHandlePart(title)}-${jan}`;
+}
+
+/**
+ * Slug-shape a free-form string into the part of a Shopify handle that
+ * sits before the trailing `-${jan}`. Lowercases, replaces whitespace and
+ * non-word chars with `-`, and strips leading/trailing `-`.
+ */
+function slugifyHandlePart(value: string): string {
+  return value
     .toString()
     .toLowerCase()
     .trim()
-    .replace(/[\s\W-]+/g, "-") // Replace spaces and non-word chars with -
-    .replace(/^-+|-+$/g, ""); // Remove leading/trailing -
+    .replace(/[\s\W-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
 
-  return `${slug}-${jan}`;
+// Shopify handles: lowercase letters, digits, single hyphens. No spaces,
+// no `&`, no parens, no uppercase, no leading/trailing/consecutive hyphens.
+const SHOPIFY_HANDLE_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+/**
+ * Canonicalize a user-typed handle string for a given JAN.
+ *
+ * Goal: if the operator typed something Shopify can't accept (spaces,
+ * `&`, parens, uppercase, …), clean it up. If the operator typed an
+ * already-valid slug — including a slug that intentionally omits the
+ * trailing `-${jan}` so multiple JANs can share one Shopify listing
+ * (e.g. `uni-propus-window-highlighter`) — leave it alone.
+ *
+ * Three input shapes:
+ *  - Already a valid Shopify slug → returned as-is.
+ *  - Free-form title-shaped text → slugified and `-${jan}` appended
+ *    (matching `generateHandle(title, jan)` shape).
+ *  - Empty / falsy → returns `""` so downstream callers fall through
+ *    to `proposal.handle || generateHandle(title, jan)` rather than
+ *    pinning the handle to the bare JAN.
+ */
+export function canonicalizeHandle(value: string, jan: string): string {
+  const trimmed = String(value ?? "").trim();
+  if (!trimmed) return "";
+  const janStr = String(jan || "").trim();
+  if (SHOPIFY_HANDLE_RE.test(trimmed)) return trimmed;
+  const slug = slugifyHandlePart(trimmed);
+  if (!slug) return "";
+  if (!janStr) return slug;
+  return slug.endsWith(`-${janStr}`) ? slug : `${slug}-${janStr}`;
 }
 
 export { generateSku } from "./sku";

--- a/src/lib/listing-creation-slice.ts
+++ b/src/lib/listing-creation-slice.ts
@@ -324,10 +324,19 @@ const listingCreationSlice = createSlice({
       }>,
     ) => {
       const { janCode, field, value } = action.payload;
-      if (state.proposals[janCode]) {
-        // @ts-ignore - dynamic field access
-        state.proposals[janCode][field] = value;
+      const proposal = state.proposals[janCode];
+      if (!proposal) return;
+      // The Handle column in /listings/create is a free-form text input
+      // and the operator can paste any string. Shopify handles must be
+      // slug-shape (lowercase, hyphenated, no whitespace / `&` / parens),
+      // so canonicalize at the reducer boundary. See
+      // docs/investigations/PROPOSAL_HANDLE_NOT_SLUGIFIED.md.
+      if (field === "handle" && typeof value === "string") {
+        proposal.handle = canonicalizeHandle(value, proposal.janCode);
+        return;
       }
+      // @ts-ignore - dynamic field access
+      proposal[field] = value;
     },
     add_listing_only_image: (
       state,
@@ -1268,7 +1277,7 @@ export const generate_proposals =
     }
   };
 
-import { generateHandle } from "./handle-utils";
+import { canonicalizeHandle, generateHandle } from "./handle-utils";
 
 export const approve_proposal_thunk =
   (janCode: string): AppThunk =>

--- a/tests/unit/canonicalize-handle.test.ts
+++ b/tests/unit/canonicalize-handle.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { canonicalizeHandle, generateHandle } from "$lib/handle-utils";
+
+const JAN = "4969757171813";
+
+describe("canonicalizeHandle", () => {
+  it("slugifies title-shaped free text and appends -<jan>", () => {
+    expect(
+      canonicalizeHandle("Kyowa Love & Fur Mini Sticky Notes (75)", JAN),
+    ).toBe(`kyowa-love-fur-mini-sticky-notes-75-${JAN}`);
+  });
+
+  it("returns an already-canonical slug unchanged (no double-append)", () => {
+    const canonical = `kyowa-love-fur-mini-sticky-notes-75-${JAN}`;
+    expect(canonicalizeHandle(canonical, JAN)).toBe(canonical);
+  });
+
+  it("matches generateHandle for plain titles", () => {
+    expect(canonicalizeHandle("Hello World", JAN)).toBe(
+      generateHandle("Hello World", JAN),
+    );
+  });
+
+  it("passes through a clean slug unchanged (preserves multi-JAN shared listings)", () => {
+    // Multiple JANs intentionally sharing one Shopify handle (e.g. the
+    // five "uni-propus-window-highlighter" colors) rely on the slug NOT
+    // having a -<jan> suffix appended.
+    expect(canonicalizeHandle("uni-propus-window-highlighter", JAN)).toBe(
+      "uni-propus-window-highlighter",
+    );
+    expect(canonicalizeHandle("my-cute-pup", JAN)).toBe("my-cute-pup");
+  });
+
+  it("rejects almost-clean slugs that contain uppercase or spaces", () => {
+    expect(canonicalizeHandle("My-Cute-Pup", JAN)).toBe(`my-cute-pup-${JAN}`);
+    expect(canonicalizeHandle("my cute pup", JAN)).toBe(`my-cute-pup-${JAN}`);
+  });
+
+  it("trims, lowercases, and collapses whitespace + punctuation", () => {
+    expect(canonicalizeHandle("  AmiFA  Mini --  Sticker (Red)  ", JAN)).toBe(
+      `amifa-mini-sticker-red-${JAN}`,
+    );
+  });
+
+  it("treats empty input as empty so callers fall back to generateHandle()", () => {
+    expect(canonicalizeHandle("", JAN)).toBe("");
+    expect(canonicalizeHandle("   ", JAN)).toBe("");
+  });
+
+  it("passes the bare JAN through unchanged (it's a valid slug)", () => {
+    expect(canonicalizeHandle(JAN, JAN)).toBe(JAN);
+  });
+});

--- a/tests/unit/update-proposal-field-handle-slug.test.ts
+++ b/tests/unit/update-proposal-field-handle-slug.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import { rootReducer } from "$lib/root-reducer";
+import {
+  add_proposals,
+  update_proposal_field,
+} from "$lib/listing-creation-slice";
+
+// docs/investigations/PROPOSAL_HANDLE_NOT_SLUGIFIED.md: the production
+// burst on JAN 4969757171813 stored a free-form title in proposal.handle
+// because the reducer wrote whatever the operator typed verbatim. After
+// the fix, the same payload should produce a slug-shaped canonical handle.
+
+const JAN = "4969757171813";
+const FREE_FORM_HANDLE = "Kyowa Kawaii Puppy Dog Love & Fur Sticky Notes (75)";
+const CANONICAL_FOR_FREE_FORM = `kyowa-kawaii-puppy-dog-love-fur-sticky-notes-75-${JAN}`;
+
+function seed() {
+  let state = rootReducer(undefined, { type: "@@INIT" });
+  state = rootReducer(
+    state,
+    add_proposals([
+      {
+        janCode: JAN,
+        photoGroupIds: [],
+        title: "Dobutsu Love & Fur Dog Sticky Notes",
+        bodyHtml: "",
+        productCategory: "Stationery",
+        vendor: "Dobutsu",
+        tags: [],
+        option1Name: "Subtype",
+        variants: [],
+        photoGroupKey: JAN,
+      } as any,
+    ]) as any,
+  );
+  return state;
+}
+
+describe("update_proposal_field — handle canonicalization", () => {
+  it("slugifies a title-shaped value typed into the handle field", () => {
+    let state = seed();
+    state = rootReducer(
+      state,
+      update_proposal_field({
+        janCode: JAN,
+        field: "handle",
+        value: FREE_FORM_HANDLE,
+      } as any) as any,
+    );
+    expect(state.listingCreation.proposals[JAN].handle).toBe(
+      CANONICAL_FOR_FREE_FORM,
+    );
+  });
+
+  it("leaves an already-canonical slug unchanged", () => {
+    let state = seed();
+    state = rootReducer(
+      state,
+      update_proposal_field({
+        janCode: JAN,
+        field: "handle",
+        value: CANONICAL_FOR_FREE_FORM,
+      } as any) as any,
+    );
+    expect(state.listingCreation.proposals[JAN].handle).toBe(
+      CANONICAL_FOR_FREE_FORM,
+    );
+  });
+
+  it("does not slugify other fields (title still accepts free text)", () => {
+    let state = seed();
+    const messyTitle = "Kyowa Love & Fur Mini Sticky Notes (75)";
+    state = rootReducer(
+      state,
+      update_proposal_field({
+        janCode: JAN,
+        field: "title",
+        value: messyTitle,
+      } as any) as any,
+    );
+    expect(state.listingCreation.proposals[JAN].title).toBe(messyTitle);
+  });
+});


### PR DESCRIPTION
## Summary

Implements **Option 2** from `docs/investigations/PROPOSAL_HANDLE_NOT_SLUGIFIED.md`. The Handle column in `/listings/create` is a free-form text input and `update_proposal_field` stored whatever the operator typed verbatim, so a typed title like "Kyowa Love & Fur Mini Sticky Notes (75)" propagated unchanged into `inventory.idToItem[*].handle` and `listings.handleToListing`, then desynced from Shopify on upload.

Fix: special-case `field === "handle"` in the `update_proposal_field` reducer and route through a new `canonicalizeHandle()` helper in `handle-utils.ts`.

`canonicalizeHandle(value, jan)`:
- **Already a valid Shopify slug** (lowercase, digits, single hyphens) → pass through unchanged. Preserves the multi-JAN shared-listing pattern (e.g. `uni-propus-window-highlighter` as one handle over 5 colour JANs) and any operator-typed canonical slug.
- **Free-form text with invalid chars** (spaces, `&`, parens, uppercase) → slugify and append `-<jan>`, matching `generateHandle()`'s shape.
- **Empty / falsy** → return `""` so the downstream `proposal.handle || generateHandle(title, jan)` fallback still works.

## Blast radius — zero historical impact

Replayed all 24,799 Apr 25 backup actions through `rootReducer` on `main` vs the fix and diffed four slices:

| Slice | Entries | Changed |
|---|---:|---:|
| `listingCreation.proposals[*].handle` | 26 | 0 |
| `inventory.idToItem[*].handle` | 838 | 0 |
| `listings.idToHandle` | 1254 | 0 |
| `listings.handleToListing` keys | 779 | 0 |

Byte-identical historical state. Reaching zero required two refinements the replay surfaced: (1) passing clean slugs through unchanged so merge-by-handle and multi-JAN shared listings keep working; (2) returning `""` for empty input so the title-derived fallback isn't pinned to the bare JAN. Detail in the commit message.

The fix only changes behavior for *future* actions where an operator types Shopify-invalid handle text.

## Test plan

- [x] `tests/unit/canonicalize-handle.test.ts` — helper: title-shaped text, already-canonical slug, clean slug pass-through (multi-JAN), uppercase/space rejection, empty → "", bare JAN
- [x] `tests/unit/update-proposal-field-handle-slug.test.ts` — reducer boundary: slugifies handle, leaves canonical untouched, does NOT slugify `title`
- [x] `scripts/handle-slugify-blast-radius.ts` — before/after replay capture + diff (zero diff)
- [x] `bun run check` — clean
- [x] Full unit suite — 329 passed, 1 skipped
- [x] Pre-push hook (live fixtures + non-live E2E, 26 Playwright specs) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)