### PR TITLE
docs: console.error census of the Apr 25 backup replay

### DIFF
--- a/docs/investigations/README.md
+++ b/docs/investigations/README.md
@@ -6,3 +6,4 @@ Records of technical investigations.
 - [Ghost-access "missing" rows — Apr 2026 audit](./GHOST_MISSING_15_AUDIT.md)
 - [Phantom "red" variant on JAN 4542804113471 — Shopify-import MATCH path](./SHOPIFY_IMPORT_OPTION1_PHANTOM_VARIANT.md)
 - [Spaces in Shopify handles — proposal handle never slugified](./PROPOSAL_HANDLE_NOT_SLUGIFIED.md)
+- [console.error census — Apr 25 backup replay](./REPLAY_CONSOLE_ERRORS.md)

--- a/docs/investigations/REPLAY_CONSOLE_ERRORS.md
+++ b/docs/investigations/REPLAY_CONSOLE_ERRORS.md
@@ -1,0 +1,205 @@
+# `console.error` census — Apr 25 backup replay
+
+## Scope
+
+Replays all 24,799 broadcast actions from the Apr 25 production backup
+(`../production-backup-apr-25/firestore-export.json`) through
+`rootReducer` with `console.error` monkeypatched to tally every message
+by normalized category, the triggering action type, counts, and a
+representative example.
+
+Goal: enumerate every distinct error the reducer pipeline emits during
+a faithful replay and recommend what to do about each category.
+
+Read-only analysis. No code change in this doc.
+
+Methodology / reproducer: `scripts/replay-console-error-census.ts`.
+
+## Headline result
+
+```
+total console.error calls : 93
+distinct semantic categories : 1
+```
+
+Every single `console.error` during a full replay is the **same
+message**:
+
+```
+[InventoryValidation] Item update ID mismatch!
+  Passed ID: "<JAN>",
+  Expected Canonical ID: "<JAN><Subtype>"
+  (JAN: "<JAN>", Subtype: "<Subtype>")
+```
+
+The census script reports "64 distinct categories" but that is an
+artifact of the normalizer keeping the human-readable subtype text
+("Flake Stickers", "Deco Seals", "Pink", "Masterpiece 1", …). Collapse
+the subtype and it is exactly one category, with **100% of occurrences
+triggered by `shopifyImport/import_batch`**.
+
+No other reducer in the pipeline emits `console.error` on this backup:
+no `[InventoryDebug]` state-shape errors, no replay exceptions, no
+merge-conflict errors, nothing from the order-import, listings,
+photos, catalog-sync, or key-audit slices.
+
+## The one category
+
+### What it is
+
+Emitted at `src/lib/inventory.ts:651`, inside `applyInventoryUpdate`:
+
+```ts
+if (item.janCode) {
+  const canonicalId = makeInventoryItemKey(item.janCode, item.subtype || "");
+  if (id !== canonicalId &&
+      canonicalizeInventoryItemKey(id) === canonicalId) {
+    id = canonicalId;            // auto-correct path (does NOT fire here)
+  }
+  if (id !== canonicalId) {
+    console.error(
+      `[InventoryValidation] Item update ID mismatch! Passed ID: "${id}", `
+      + `Expected Canonical ID: "${canonicalId}" `
+      + `(JAN: "${item.janCode}", Subtype: "${item.subtype || ""}")`,
+    );
+  }
+}
+```
+
+The validator checks that the inventory map key (`id`) equals
+`makeInventoryItemKey(janCode, subtype)`. There is an auto-correct
+branch, but it only fires when `canonicalizeInventoryItemKey(id)`
+already equals the canonical id — i.e. when the id is structurally a
+canonical key that just needs whitespace/format normalization. It
+cannot fire here because the passed `id` is a **bare JAN** with no
+subtype component, while the item carries a non-empty `subtype`. There
+is no way to recover the subtype from the bare JAN, so auto-correct is
+skipped, the error is logged, and **the update proceeds anyway** —
+writing the row under the bare-JAN key (`state.idToItem[id]` at
+`inventory.ts:692` with the un-corrected `id`).
+
+### Why it fires — root cause
+
+`computeShopifyImportBatch` (`src/lib/shopify-import-slice.ts`) builds
+its update list with a bare-JAN id while moving the Shopify Option1
+value into the item's `subtype` field. Both branches do this:
+
+- **MATCH branch** (`shopify-import-slice.ts:~413`):
+  ```ts
+  const newItem = { ...baseItem, …, subtype: item.option1Value || baseItem.subtype };
+  updates.push({ type: "update", id: key, item: newItem });
+  ```
+  `key` is the existing inventory map key, which for these products is
+  the bare JAN.
+
+- **NEW branch** (`shopify-import-slice.ts:482-495`):
+  ```ts
+  const itemWithSubtype = { ...item, subtype: item.option1Value || "" };
+  updates.push({ type: "new", id: item.janCode, item: itemWithSubtype });
+  ```
+  `id` is explicitly `item.janCode` (bare JAN) while `subtype` is set
+  from the Shopify Option1 value.
+
+So whenever a Shopify product carries an Option1 value (i.e. has a
+real variant subtype — which is most catalogued products), the import
+emits an update whose id (bare JAN) disagrees with its
+`janCode + subtype`. `applyInventoryUpdate` flags exactly that
+disagreement.
+
+This is the **same root cause** documented in
+`docs/investigations/SHOPIFY_IMPORT_OPTION1_PHANTOM_VARIANT.md`: the
+Shopify import lifts `option1Value` into `subtype` without re-keying
+`idToItem`. The `console.error` census is the diagnostic shadow of
+that bug — every "phantom variant" write announces itself here first.
+
+### Severity
+
+- **The log itself is benign** — it does not throw, does not abort the
+  replay, and the import still applies. So it is not an availability
+  problem.
+- **What it indicates is not benign** — each line marks an inventory
+  row being written under a non-canonical key (bare JAN with a
+  subtype field that disagrees). That is the malformed-row condition
+  analyzed in the phantom-variant investigation: the UI then renders
+  a "variant" whose key doesn't match its subtype, and Shopify
+  round-trips desync.
+- **Volume**: 93 occurrences across a ~7-month action history; ~all
+  concentrated in `shopifyImport/import_batch` runs. Low frequency,
+  but each one is a real data-shape defect, not noise.
+
+### Recommendation
+
+This category does not warrant its own fix — it should be resolved by
+fixing the upstream import, which is already scoped in
+`SHOPIFY_IMPORT_OPTION1_PHANTOM_VARIANT.md`. Concretely, ranked:
+
+1. **Fix the import to canonicalize on write** (primary). In
+   `computeShopifyImportBatch`, when `item.option1Value` (→ subtype)
+   is non-empty, push the update under
+   `makeInventoryItemKey(item.janCode, subtype)` instead of the bare
+   JAN — and re-key any existing bare-JAN row. This eliminates the
+   root cause; the `console.error` then naturally goes silent because
+   the ids will be canonical. Mirrors the fix shape already shipped
+   for proposal handles (`canonicalizeHandle` at the reducer
+   boundary) and the `retype_item` shipped-counter decoupling.
+
+2. **Strengthen `applyInventoryUpdate`'s auto-correct** (defense in
+   depth). Today auto-correct only handles the
+   "structurally-canonical-but-unnormalized" case. It could also
+   handle the "bare JAN + explicit subtype in payload" case: if
+   `id === item.janCode` and `item.subtype` is non-empty and
+   `state.idToItem[canonicalId]` is absent, treat it as the canonical
+   write (optionally migrating an existing bare-JAN row). This makes
+   the reducer robust regardless of which caller is sloppy — same
+   "canonicalize on write, not on read" principle as the other
+   investigations. Pair with a one-time data migration for rows
+   already written under bare-JAN keys.
+
+3. **Promote the log to a jailed action** (observability). If the
+   team wants this to be loud rather than silent-with-a-log, route
+   the mismatch through the existing `keyAudit` instrumentation
+   (`ghostMap` / `canonicalCollisions`) or the `jailed` collection,
+   so it surfaces on the audit page instead of only in the console.
+   This is orthogonal to the fix and only worth doing if #1 is
+   deferred.
+
+4. **Do nothing to the log specifically.** It is a correct,
+   well-formed diagnostic. Once #1 lands it stops firing on its own.
+   There is no value in suppressing or downgrading the message while
+   the underlying bare-JAN writes still happen — that would hide the
+   phantom-variant defect.
+
+The recommended path is **#1**, tracked under the phantom-variant
+investigation, with **#2** as a cheap reducer-level safety net that
+also retro-protects against any other caller passing a bare JAN with
+a subtype. No action is needed on categories 2..N because there are
+none.
+
+## What the absence of other errors tells us
+
+Equally important: a faithful 24,799-action replay produces **zero**
+errors from any slice other than this one validator. The
+`[InventoryDebug]` guard rails (missing state, missing idToHistory,
+missing idToItem), the merge-conflict paths, the order-import and
+catalog-sync reducers, and the key-audit pipeline all run clean on
+real production data. The reducer pipeline is, on this evidence,
+healthy except for the single known import-canonicalization defect.
+
+(Note: `console.warn` is a separate, much noisier channel —
+`Skipping update_field for missing item`, `Skipping package_item for
+missing item`, `Variant ID collision`, etc. Those are catalogued
+under `GHOST_MISSING_15_AUDIT.md` and the phantom-variant doc and are
+out of scope here, which is strictly `console.error`.)
+
+## Reproduction
+
+```bash
+bun run scripts/replay-console-error-census.ts 2>&1 \
+  | sed -n '/===== console.error census =====/,$p'
+```
+
+The script monkeypatches `console.error` before importing
+`rootReducer` (so module-load logging is captured too), replays the
+backup, normalizes each message (masking JANs/URLs/hex/ids/digits),
+and prints per-category counts, an example, and the triggering action
+type distribution.

--- a/scripts/replay-console-error-census.ts
+++ b/scripts/replay-console-error-census.ts
@@ -1,0 +1,109 @@
+// Census of every console.error emitted while replaying the Apr 25
+// production backup through rootReducer. Monkeypatches console.error,
+// normalizes each message into a category (stripping ids/jans/urls),
+// and prints counts + a representative example + the triggering action
+// type distribution per category.
+
+import { readFileSync } from "fs";
+
+const realError = console.error.bind(console);
+
+const BACKUP =
+  "/Users/anicolao/projects/antigravity/production-backup-apr-25/firestore-export.json";
+
+function tsKey(a: any): number {
+  const ts = a?.timestamp;
+  if (typeof ts?._seconds === "number")
+    return ts._seconds * 1_000_000_000 + (Number(ts._nanoseconds) || 0);
+  if (typeof ts?.seconds === "number")
+    return ts.seconds * 1_000_000_000 + (Number(ts.nanoseconds) || 0);
+  return 0;
+}
+
+function normalize(msg: string): string {
+  return msg
+    .replace(/\b\d{8,}\b/g, "<JAN>")
+    .replace(/https?:\/\/\S+/g, "<URL>")
+    .replace(/\b[0-9a-fA-F]{16,}\b/g, "<HEX>")
+    .replace(/\b[A-Za-z0-9_-]{20,}\b/g, "<ID>")
+    .replace(/\d+/g, "<N>")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 200);
+}
+
+interface Bucket {
+  count: number;
+  example: string;
+  actionTypes: Record<string, number>;
+}
+
+const buckets = new Map<string, Bucket>();
+let currentActionType = "<none>";
+let totalErrors = 0;
+
+console.error = (...args: any[]) => {
+  totalErrors++;
+  const msg = args
+    .map((a) => {
+      if (typeof a === "string") return a;
+      if (a instanceof Error) return a.message;
+      try {
+        return JSON.stringify(a);
+      } catch {
+        return String(a);
+      }
+    })
+    .join(" ");
+  const key = normalize(msg);
+  let b = buckets.get(key);
+  if (!b) {
+    b = { count: 0, example: msg.slice(0, 300), actionTypes: {} };
+    buckets.set(key, b);
+  }
+  b.count++;
+  b.actionTypes[currentActionType] =
+    (b.actionTypes[currentActionType] || 0) + 1;
+};
+
+// Import AFTER patching so any module-load-time logging is captured too.
+const { rootReducer } = await import("../src/lib/root-reducer");
+
+const docs = JSON.parse(readFileSync(BACKUP, "utf-8")).collections.broadcast
+  .documents;
+const actions = docs
+  .map((d: any) => ({ id: d.id, ...d.data }))
+  .sort((a: any, b: any) => tsKey(a) - tsKey(b));
+
+let state: any = rootReducer(undefined, { type: "@@INIT" });
+for (let i = 0; i < actions.length; i++) {
+  currentActionType = actions[i]?.type || "<none>";
+  try {
+    state = rootReducer(state, actions[i] as any, () => {});
+  } catch (e) {
+    console.error(`__replay_threw__ ${(e as Error).message}`);
+  }
+}
+
+console.error = realError;
+
+const sorted = [...buckets.entries()].sort((a, b) => b[1].count - a[1].count);
+
+realError(`\n===== console.error census =====`);
+realError(`total console.error calls: ${totalErrors}`);
+realError(`distinct categories: ${sorted.length}\n`);
+
+let idx = 1;
+for (const [key, b] of sorted) {
+  const topActions = Object.entries(b.actionTypes)
+    .sort((x, y) => y[1] - x[1])
+    .slice(0, 5)
+    .map(([t, c]) => `${t}:${c}`)
+    .join(", ");
+  realError(`#${idx} [count=${b.count}]`);
+  realError(`  pattern : ${key}`);
+  realError(`  example : ${b.example.replace(/\n/g, " ")}`);
+  realError(`  actions : ${topActions}`);
+  realError("");
+  idx++;
+}


### PR DESCRIPTION
## Summary

Adds `docs/investigations/REPLAY_CONSOLE_ERRORS.md`. Replays all 24,799 Apr 25 backup actions through `rootReducer` with `console.error` monkeypatched, categorizing every emission.

**Result: 93 `console.error` calls, exactly one semantic category** — `[InventoryValidation] Item update ID mismatch!` (`inventory.ts:651`), 100% triggered by `shopifyImport/import_batch`. No other slice emits `console.error` on real production data (clean: `[InventoryDebug]` guards, merge-conflict paths, order-import, catalog-sync, key-audit).

Root cause is the already-documented one from `SHOPIFY_IMPORT_OPTION1_PHANTOM_VARIANT.md`: `computeShopifyImportBatch` pushes updates with a bare-JAN id while moving the Shopify Option1 value into `item.subtype`, so `applyInventoryUpdate`'s canonical-key validator fires (auto-correct can't recover a subtype from a bare JAN) and the row is written under a non-canonical key.

The doc ranks four responses:
1. Fix the import to canonicalize on write (primary; scoped under the phantom-variant investigation).
2. Reducer-level auto-correct for the "bare JAN + explicit subtype" case + one-time data migration (defense in depth).
3. Route the mismatch through `keyAudit`/`jailed` for visibility (observability, optional).
4. Don't suppress the log — it goes silent on its own once #1 lands.

Also notes the positive finding: the reducer pipeline is otherwise clean on a faithful full-history replay. `console.warn` is explicitly out of scope (covered by the ghost/phantom-variant docs).

Adds `scripts/replay-console-error-census.ts` as the reproducer. No code change.

## Test plan

- [x] Census reproducer verified locally against `../production-backup-apr-25/firestore-export.json`
- [x] `bun run check` — clean (docs-only; pre-commit ran full type-check + unit suite)
- [x] Pre-push hook (live fixtures + non-live E2E, 26 Playwright specs) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)