### PR TITLE
fix(listing-detail): allow removing an erroneous subtype on live listings

### DIFF
--- a/e2e/015-listings-creation/variant-updates.spec.ts
+++ b/e2e/015-listings-creation/variant-updates.spec.ts
@@ -276,4 +276,141 @@ test.describe("Variant Updates (Modal-driven)", () => {
     expect(payload.splits[0].subtype).toBe("M");
     expect(payload.splits[0].qty).toBe(2);
   });
+
+  test("User can remove an erroneous subtype from a Live listing without zeroing inventory", async ({
+    authenticatedPage: page,
+  }) => {
+    test.setTimeout(120000);
+
+    const janCode = "LIVE-REMOVE-TEST";
+    const keepId = `${janCode}Good`; // canonical inventory key
+    const errId = `${janCode}Bad`; // erroneous subtype to remove
+    const handle = "live-remove-handle";
+
+    await page.goto(`/listing-detail?mode=live&handle=${handle}`);
+    await waitForAppReady(page);
+    await page.waitForFunction(() => (window as any).testHelpers);
+    await page.waitForFunction(
+      () => (window as any).testHelpers.store.getState().inventory.initialized,
+      { timeout: 60000 },
+    );
+
+    // Capture qty + handle update_field actions.
+    await page.evaluate(() => {
+      const { store } = (window as any).testHelpers;
+      (window as any).broadcastHistory = [];
+      const originalDispatch = store.dispatch;
+      store.dispatch = (action: any) => {
+        if (action.type === "update_field")
+          (window as any).broadcastHistory.push(action);
+        return originalDispatch(action);
+      };
+    });
+
+    // Two variants on one live listing: a good one and an erroneous one.
+    await page.evaluate(
+      ({ janCode, keepId, errId, handle }) => {
+        const { store, actions } = (window as any).testHelpers;
+        store.dispatch(
+          actions.bulk_import_items({
+            items: [
+              {
+                id: keepId,
+                item: { janCode, subtype: "Good", qty: 7, handle },
+                type: "new",
+              },
+              {
+                id: errId,
+                item: { janCode, subtype: "Bad", qty: 4, handle },
+                type: "new",
+              },
+            ],
+          }),
+        );
+        store.dispatch(
+          actions.create_listing({
+            handle,
+            listing: { handle, title: "Live Remove Test", images: [] },
+          }),
+        );
+      },
+      { janCode, keepId, errId, handle },
+    );
+
+    await expect(
+      page.locator(".subtype-label", { hasText: "Good" }).first(),
+    ).toBeVisible({ timeout: 10000 });
+
+    await page.click('button:has-text("Manage Variants")');
+
+    // Mark the erroneous "Bad" variant for removal.
+    await page
+      .locator(".allocation-row", { hasText: "Bad" })
+      .first()
+      .locator(".row-remove-btn")
+      .click();
+    await expect(
+      page.locator(".allocation-row", { hasText: "Bad" }).first(),
+    ).toHaveClass(/is-removed/);
+
+    // The fix: a removal-only change balances, so Confirm is enabled.
+    const saveBtn = page.locator("button.btn-save");
+    await expect(saveBtn).toBeEnabled();
+    await saveBtn.click();
+
+    await page.waitForFunction(
+      () =>
+        (window as any).broadcastHistory.some(
+          (a: any) =>
+            a.payload?.field === "handle" && a.payload?.to === "",
+        ),
+      undefined,
+      { timeout: 10000 },
+    );
+
+    const actionsFired = await page.evaluate(
+      () => (window as any).broadcastHistory,
+    );
+
+    // The erroneous variant is detached (handle cleared)...
+    const handleClear = actionsFired.find(
+      (a: any) =>
+        a.payload?.id === errId &&
+        a.payload?.field === "handle" &&
+        a.payload?.to === "",
+    );
+    expect(handleClear).toBeTruthy();
+
+    // ...but its inventory qty is NOT zeroed (no qty update for it)...
+    const errQtyWrite = actionsFired.find(
+      (a: any) => a.payload?.id === errId && a.payload?.field === "qty",
+    );
+    expect(errQtyWrite).toBeFalsy();
+
+    // ...and the kept variant's qty is untouched.
+    const keepQtyWrite = actionsFired.find(
+      (a: any) => a.payload?.id === keepId && a.payload?.field === "qty",
+    );
+    expect(keepQtyWrite).toBeFalsy();
+
+    // Inventory state: kept qty intact, erroneous qty preserved (not
+    // zeroed), erroneous variant detached from the listing.
+    const finalState = await page.evaluate(
+      ({ keepId, errId }) => {
+        const inv = (
+          window as any
+        ).testHelpers.store.getState().inventory.idToItem;
+        return {
+          keepQty: inv[keepId]?.qty,
+          errQty: inv[errId]?.qty,
+          errHandle: inv[errId]?.handle,
+        };
+      },
+      { keepId, errId },
+    );
+
+    expect(finalState.keepQty).toBe(7);
+    expect(finalState.errQty).toBe(4);
+    expect(finalState.errHandle).toBe("");
+  });
 });

--- a/src/lib/components/ListingVariantModal.svelte
+++ b/src/lib/components/ListingVariantModal.svelte
@@ -110,9 +110,19 @@
   // Total available is sum of all variants currently on listing
   // PLUS the quantity of any NEW item being brought in.
   $: totalAvailable = (() => {
-    // Sum unique inventory item quantities
+    // Sum unique inventory item quantities. Rows marked for removal are
+    // excluded from the pool: removing an erroneous subtype discards
+    // that variant rather than redistributing its units, so the
+    // conservation invariant must balance over the *kept* variants
+    // only. Without this a removal-only change can never balance and
+    // Confirm stays disabled. See
+    // docs/investigations/MANAGE_VARIANTS_CANNOT_REMOVE.md.
     const sourceMap = new Map<string, number>();
-    associatedItems.forEach((i) => sourceMap.set(i.id, i.qty || 0));
+    associatedItems.forEach((i) => {
+      const rowId = i.variantId || i.id;
+      if (pendingRemovals.has(rowId)) return;
+      sourceMap.set(i.id, i.qty || 0);
+    });
     if (selectedItemToAdd) {
       if (!sourceMap.has(selectedItemToAdd.id)) {
         sourceMap.set(selectedItemToAdd.id, selectedItemToAdd.qty || 0);

--- a/src/routes/listing-detail/+page.svelte
+++ b/src/routes/listing-detail/+page.svelte
@@ -1829,8 +1829,14 @@
     showVariantModal = false;
 
     if (isLiveMode && handle) {
-      // 1. Apply all quantity changes
+      // 1. Apply all quantity changes. Skip rows scheduled for removal:
+      // toggleRemoval zeroes their proposedQtys, and detaching a variant
+      // from a listing must not also zero a real inventory row's qty.
+      // handleRemovals (below) clears the handle to detach it. See
+      // docs/investigations/MANAGE_VARIANTS_CANNOT_REMOVE.md.
+      const removalSet = new Set(removals);
       Object.entries(proposedQtys).forEach(([itemId, newQty]) => {
+        if (removalSet.has(itemId)) return;
         const item = $store.inventory.idToItem[itemId];
         if (item && item.qty !== newQty) {
           console.log(


### PR DESCRIPTION
## Summary

Implements the two-part fix from `docs/investigations/MANAGE_VARIANTS_CANNOT_REMOVE.md`.

Manage Variants gated **Confirm** on a quantity-conservation invariant (`totalAllocated === totalAvailable`). `toggleRemoval` zeroes a removed row's `proposedQtys` (dropping `totalAllocated`), but `totalAvailable` still summed *every* `associatedItems` entry including the removed one — so a pure removal could never balance and Confirm stayed permanently disabled. There was no UI path to detach an incorrectly-created subtype from a live listing.

- **Part 1** (`ListingVariantModal.svelte`): exclude `pendingRemovals` rows from `totalAvailable` so a removal-only change balances over the *kept* variants and Confirm enables. Split/add unaffected (no removals ⇒ identical pool).
- **Part 2** (`listing-detail/+page.svelte`, `onConfirmManage` live branch): skip the qty update for ids in `removals`, so detaching a variant clears its handle without also forcing a real inventory row's qty to 0 (a secondary bug found in the investigation).

## Inventory impact check (as requested)

**Part A — full Apr 25 replay before/after (24,799 actions):** **ZERO diff** across `idToItem` (0 added / 0 removed / 0 fingerprint-changed), `idToHistory` (0/0), order line sets (0), and `console.error` (0/0). The change is pure UI and is not on the `rootReducer` replay path, so it **cannot retroactively or accidentally affect any inventory count** for existing data. (`scripts/canonicalize-write-blast-radius.ts`, before=main / after=branch.)

**Part B — behavioral E2E** (`variant-updates.spec.ts`, new live-remove test): inject a live listing with a kept variant (qty 7) and an erroneous one (qty 4); mark the erroneous one for removal. Asserts:
- Confirm becomes **enabled** (the fix),
- removed variant detached: `update_field(handle → "")` dispatched,
- removed variant qty **not** zeroed: no `update_field(qty)` for it; final `idToItem` qty stays **4**,
- kept variant untouched: no qty write; final qty stays **7**.

## Test plan

- [x] `bun run check` clean
- [x] New E2E live-remove test + both existing 015 specs green (managed harness and pre-push)
- [x] Full Apr 25 replay before/after — zero inventory diff
- [x] Pre-commit (check + full unit suite) and pre-push (live fixtures + 26 non-live E2E specs) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)