### PR TITLE
docs: profile full replay performance (Apr 25 backup)

### DIFF
--- a/docs/investigations/README.md
+++ b/docs/investigations/README.md
@@ -8,3 +8,4 @@ Records of technical investigations.
 - [Spaces in Shopify handles — proposal handle never slugified](./PROPOSAL_HANDLE_NOT_SLUGIFIED.md)
 - [console.error census — Apr 25 backup replay](./REPLAY_CONSOLE_ERRORS.md)
 - [Manage Variants modal cannot remove an erroneous subtype](./MANAGE_VARIANTS_CANNOT_REMOVE.md)
+- [Replay performance — Apr 25 backup profile](./REPLAY_PERFORMANCE.md)

--- a/docs/investigations/REPLAY_PERFORMANCE.md
+++ b/docs/investigations/REPLAY_PERFORMANCE.md
@@ -1,0 +1,163 @@
+# Replay performance — Apr 25 backup profile
+
+## Question
+
+Full replay of the production action log feels slow, and subjectively
+the actions past ~22,000 seem to take a long time. Profile it and
+explain.
+
+Methodology / reproducer: `scripts/profile-replay.ts` (times every
+action through `rootReducer`, buckets wall-time per 1000 actions,
+samples state size per bucket, ranks cost by action type and the
+slowest individual actions). Backup:
+`../production-backup-apr-25/firestore-export.json` (24,799 actions).
+
+## Headline numbers
+
+```
+Total: 81.8 s   24,799 actions   mean 3.30 ms/action   (~303 actions/s)
+```
+
+The cost is **not** spread across the tail and is **not** caused by
+state growing. It is one action type, densely batched.
+
+### Wall time per 1000-action bucket
+
+```
+   0–21000   ~0.2–1.1 ms/action   (each 1k bucket: 0.2s–1.1s)
+21000–22000  19.3 s   (19.3 ms/action)   ← spike begins
+22000–23000  44.9 s   (44.9 ms/action)   ← peak
+23000–24799  ~0.9–1.9 ms/action  (back to normal)
+```
+
+Buckets 21k–23k alone are **~64 s of the 81.8 s total (78%)**. The
+user's "22,000+ is slow" observation is real — but it is an
+*index-range* artifact, not a position/size effect (see below).
+
+### Cost by action type (top of list)
+
+```
+type                              count   totalMs   avgMs   maxMs
+photos/shopify_cdn_uploaded         703     60467   86.013  108.5
+photos/complete_upload             3399      5010    1.474    3.8
+listingCreation/approve_proposal    280      4268   15.244   54.0
+photos/complete_edit               2776      3153    1.136    4.9
+update_item                        1225      1071    0.875    7.4
+shopifyImport/import_batch            1       211  210.894  210.9
+... (everything else < 2 ms/action)
+```
+
+**`photos/shopify_cdn_uploaded` is 60.5 s — 74% of the entire
+replay** — at ~86 ms/action across 703 actions. The 30 slowest
+individual actions are *all* `photos/shopify_cdn_uploaded`, every one
+in index range **21,584–23,015** — exactly the 21k–23k spike. This is
+a bulk Shopify-CDN→Drive image-migration episode that happened in that
+window; the actions are clustered by index purely because they were
+broadcast together.
+
+The lone `shopifyImport/import_batch` (211 ms at index 3809) explains
+the small 3k–4k bump and is a harmless one-off.
+
+### State size is flat — it is not an O(n)-over-growing-state problem
+
+Per-bucket state sampling:
+
+```
+atIndex idToItem orders ordLines ghostMap handleToListing
+   4000     1102     51     1051       14   524
+  12000     1180     51     1051       23   606
+  22000     1312     51     1051       28   779
+  24799     1316     51     1051       37   779
+```
+
+From bucket ~4000 onward `idToItem`, `orders`, `orderLines` are
+essentially constant. The slowdown is therefore **not** a quadratic
+"scan grows as state grows" effect. It is a *fixed* heavy per-action
+cost that simply gets paid 703 times in a row during the migration
+burst.
+
+## Root cause
+
+`rootReducer`'s `photos/shopify_cdn_uploaded` handler
+(`src/lib/root-reducer.ts:544`) does, **on every action**:
+
+1. `const nextIdToItem = { ...inventoryState.idToItem }` — full clone
+   of ~1,316 inventory entries.
+2. `Object.entries(nextIdToItem).forEach(...)` — iterate **all**
+   ~1,316 items, calling `canonicalizeShopifyCdnUrl(item.image)` for
+   each. `canonicalizeShopifyCdnUrl` runs `new URL(value)` plus regex
+   work — an expensive parse — per item.
+3. `const nextHandleToListing = { ...listingsState.handleToListing }`
+   — full clone of ~779 listings.
+4. `Object.entries(nextHandleToListing).forEach(...)` — iterate **all**
+   ~779 listings and, for each, iterate its `images[]`, calling
+   `canonicalizeShopifyCdnUrl(img.url)` (another `new URL()`) per
+   image.
+
+The set of URLs that can actually match is tiny — `sourceCandidates`
+is ≤ 4 URLs derived from the action payload. Yet every action
+re-parses and re-canonicalizes the image URL of *every* inventory
+item and *every* listing image, and clones both maps wholesale, even
+though in the overwhelmingly common case nothing matches.
+
+Quantitatively: ~1,316 item images × 703 actions ≈ **0.9 million
+redundant `new URL()` parses** on inventory alone, plus the listing
+image scan, plus 703 full clones of two large maps. At ~86 ms each
+that is the 60 s.
+
+This is the same family as the other investigations (work scoped to
+"all of X" when the relevant set is "the few matching Y"), here as a
+*performance* rather than *correctness* defect.
+
+## Scope / impact
+
+- **Cold start only.** This cost is paid during full replay /
+  state hydration and on the audit page's replay. In live operation
+  actions arrive one at a time; 86 ms once is invisible. The pain is
+  (a) cold hydrate after a schema-version bump, (b) the audit/replay
+  tooling, (c) CI/test replays.
+- No correctness issue — the output is right, just slowly produced.
+
+## Recommendations (no behavior change)
+
+In rough order of leverage / smallness:
+
+1. **Memoize `canonicalizeShopifyCdnUrl` (and the
+   deleted/non-deleted path variants).** They are pure string→string
+   functions; the same ~1,316 item-image URLs are re-parsed 703
+   times. A module-level `Map<string,string>` cache collapses ~0.9 M
+   `new URL()` parses to ~(distinct URL count). Smallest possible
+   change, no behavior impact, likely an order-of-magnitude win on
+   this handler.
+
+2. **Short-circuit before cloning.** Compute the small `sourceSet`
+   first (already done), then do a cheap pre-scan; only allocate
+   `nextIdToItem` / `nextHandleToListing` and do the rewrite when at
+   least one item/listing image is in `sourceSet`. Most of the 703
+   actions touch only a handful of items, and many touch none.
+
+3. **Maintain a reverse index** `canonicalImageUrl → Set<itemId>`
+   (and per-listing) updated incrementally as images change, turning
+   the per-action cost from O(all items + all listing images) into
+   O(matches). This is the "proper" fix and the biggest change;
+   #1 + #2 likely make it unnecessary.
+
+Recommended: ship **#1 + #2** together — both are local to the one
+handler, behavior-preserving, and should take the replay from ~82 s
+toward roughly ~22 s (removing most of the 60 s). Validate with the
+same before/after full-replay state diff used on the inventory fixes
+(state must be byte-identical; only timing changes) plus a
+profile-replay before/after.
+
+## Reproduction
+
+```bash
+bun run scripts/profile-replay.ts 2>&1 | grep -vE \
+  "Cached|Loaded|InventoryValidation|RootReducer\]|Skipping|Reducer\]"
+```
+
+Look at: "Wall time per 1000-action bucket" (21k–23k spike),
+"Cost by action type" (`photos/shopify_cdn_uploaded` ≈ 74%),
+"State size growth" (flat ⇒ not O(n)-over-growth), and "30 slowest
+individual actions" (all `photos/shopify_cdn_uploaded`, indices
+21.5k–23k).

--- a/scripts/profile-replay.ts
+++ b/scripts/profile-replay.ts
@@ -1,0 +1,177 @@
+// Profiles a full replay of the Apr 25 production backup through
+// rootReducer. Emits: total time, per-1000-action wall-time buckets,
+// per-action-type cost, the slowest individual actions, and state-size
+// growth sampled per bucket (to correlate slowdown with O(n) scans over
+// growing state). Focus: is the 22,000+ tail disproportionately slow?
+
+import { readFileSync } from "fs";
+import { performance } from "perf_hooks";
+import { rootReducer } from "../src/lib/root-reducer";
+
+const BACKUP =
+  "/Users/anicolao/projects/antigravity/production-backup-apr-25/firestore-export.json";
+
+function tsKey(a: any): number {
+  const ts = a?.timestamp;
+  if (typeof ts?._seconds === "number")
+    return ts._seconds * 1_000_000_000 + (Number(ts._nanoseconds) || 0);
+  if (typeof ts?.seconds === "number")
+    return ts.seconds * 1_000_000_000 + (Number(ts.nanoseconds) || 0);
+  return 0;
+}
+
+const raw = readFileSync(BACKUP, "utf-8");
+const docs = JSON.parse(raw).collections.broadcast.documents;
+const actions = docs
+  .map((d: any) => ({ id: d.id, ...d.data }))
+  .sort((a: any, b: any) => tsKey(a) - tsKey(b));
+
+const N = actions.length;
+const BUCKET = 1000;
+
+interface TypeStat {
+  count: number;
+  totalMs: number;
+  maxMs: number;
+}
+const byType = new Map<string, TypeStat>();
+const perAction = new Float64Array(N);
+const bucketMs: number[] = [];
+const bucketSamples: any[] = [];
+
+const sizeOf = (s: any) => {
+  const inv = s?.inventory || {};
+  const orders = inv.orderIdToOrder || {};
+  let orderLines = 0;
+  for (const k of Object.keys(orders))
+    orderLines += (orders[k]?.items || []).length;
+  return {
+    idToItem: Object.keys(inv.idToItem || {}).length,
+    idToHistory: Object.keys(inv.idToHistory || {}).length,
+    orders: Object.keys(orders).length,
+    orderLines,
+    ghostAccessEvents: (s?.keyAudit?.ghostAccessEvents || []).length,
+    ghostMap: Object.keys(s?.keyAudit?.ghostMap || {}).length,
+    canonicalIndex: Object.keys(
+      s?.keyAudit?.canonicalIncomingIndex || {},
+    ).length,
+    handleToListing: Object.keys(s?.listings?.handleToListing || {}).length,
+    idToHandle: Object.keys(s?.listings?.idToHandle || {}).length,
+  };
+};
+
+let state: any = rootReducer(undefined, { type: "@@INIT" });
+const t0 = performance.now();
+let bucketStart = t0;
+
+for (let i = 0; i < N; i++) {
+  const a = actions[i];
+  const s = performance.now();
+  try {
+    state = rootReducer(state, a as any, () => {});
+  } catch {
+    /* mirror audit tolerance */
+  }
+  const dt = performance.now() - s;
+  perAction[i] = dt;
+  const type = a?.type || "<none>";
+  const ts = byType.get(type) || { count: 0, totalMs: 0, maxMs: 0 };
+  ts.count++;
+  ts.totalMs += dt;
+  if (dt > ts.maxMs) ts.maxMs = dt;
+  byType.set(type, ts);
+
+  if ((i + 1) % BUCKET === 0 || i === N - 1) {
+    const now = performance.now();
+    bucketMs.push(now - bucketStart);
+    bucketSamples.push({ atIndex: i + 1, ...sizeOf(state) });
+    bucketStart = now;
+  }
+}
+const totalMs = performance.now() - t0;
+
+console.log(`\n=== Replay profile: ${N} actions ===`);
+console.log(`Total: ${(totalMs / 1000).toFixed(1)}s`);
+console.log(
+  `Mean: ${(totalMs / N).toFixed(3)} ms/action  ` +
+    `(${(N / (totalMs / 1000)).toFixed(0)} actions/s)`,
+);
+
+console.log(`\n--- Wall time per ${BUCKET}-action bucket ---`);
+console.log("bucket    actions      ms     ms/action");
+bucketMs.forEach((ms, b) => {
+  const lo = b * BUCKET;
+  const hi = Math.min((b + 1) * BUCKET, N);
+  const n = hi - lo;
+  console.log(
+    `${String(lo).padStart(6)}-${String(hi).padStart(6)}  ` +
+      `${ms.toFixed(0).padStart(7)}  ${(ms / n).toFixed(3).padStart(9)}`,
+  );
+});
+
+console.log(`\n--- State size growth (per bucket) ---`);
+console.log(
+  "atIndex idToItem idToHist orders ordLines ghostEvt ghostMap canonIdx h2l idToHandle",
+);
+for (const s of bucketSamples) {
+  console.log(
+    [
+      String(s.atIndex).padStart(7),
+      String(s.idToItem).padStart(8),
+      String(s.idToHistory).padStart(8),
+      String(s.orders).padStart(6),
+      String(s.orderLines).padStart(8),
+      String(s.ghostAccessEvents).padStart(8),
+      String(s.ghostMap).padStart(8),
+      String(s.canonicalIndex).padStart(8),
+      String(s.handleToListing).padStart(4),
+      String(s.idToHandle).padStart(10),
+    ].join(" "),
+  );
+}
+
+console.log(`\n--- Cost by action type (top 20 by total ms) ---`);
+console.log("type                              count   totalMs   avgMs   maxMs");
+[...byType.entries()]
+  .sort((a, b) => b[1].totalMs - a[1].totalMs)
+  .slice(0, 20)
+  .forEach(([t, s]) => {
+    console.log(
+      `${t.padEnd(34)} ${String(s.count).padStart(5)} ` +
+        `${s.totalMs.toFixed(0).padStart(9)} ` +
+        `${(s.totalMs / s.count).toFixed(3).padStart(7)} ` +
+        `${s.maxMs.toFixed(1).padStart(7)}`,
+    );
+  });
+
+console.log(`\n--- 30 slowest individual actions ---`);
+const idx = Array.from({ length: N }, (_, i) => i).sort(
+  (a, b) => perAction[b] - perAction[a],
+);
+console.log("index   ms      type");
+for (let k = 0; k < 30; k++) {
+  const i = idx[k];
+  console.log(
+    `${String(i).padStart(5)} ${perAction[i].toFixed(1).padStart(7)}  ` +
+      `${actions[i]?.type}`,
+  );
+}
+
+// Tail focus: compare first half vs the 22k+ tail.
+const half = Math.floor(N / 2);
+const sum = (lo: number, hi: number) => {
+  let m = 0;
+  for (let i = lo; i < hi; i++) m += perAction[i];
+  return m;
+};
+const firstHalf = sum(0, half);
+const tail = sum(22000, N);
+console.log(`\n--- Tail focus ---`);
+console.log(
+  `actions 0..${half}: ${(firstHalf / 1000).toFixed(1)}s ` +
+    `(${(firstHalf / half).toFixed(3)} ms/action)`,
+);
+console.log(
+  `actions 22000..${N}: ${(tail / 1000).toFixed(1)}s ` +
+    `(${(tail / (N - 22000)).toFixed(3)} ms/action)`,
+);


### PR DESCRIPTION
## Summary

Adds `docs/investigations/REPLAY_PERFORMANCE.md` + `scripts/profile-replay.ts`.

Full replay = **81.8 s / 24,799 actions** (mean 3.30 ms/action). The cost is one action type, densely batched — not state growth:

- **`photos/shopify_cdn_uploaded`: 703 actions, 60.5 s total = 74% of the whole replay**, ~86 ms/action. The 30 slowest individual actions are all this type, clustered at indices **21,584–23,015** → that is exactly why "22,000+ is slow" *feels* true, but it's an index-range artifact of a bulk Shopify-CDN→Drive image-migration burst, not a position/size effect.
- Per-bucket: 0–21k ≈ 0.2–1.1 ms/action; **21k–22k 19.3 s; 22k–23k 44.9 s**; 23k+ back to normal. Buckets 21k–23k = ~64 s of the 81.8 s (78%).
- State size (`idToItem`/`orders`/`orderLines`) is flat from bucket ~4000 on ⇒ **not** an O(n)-over-growing-state problem.

**Root cause:** the `photos/shopify_cdn_uploaded` handler (`root-reducer.ts:544`) clones `idToItem` (~1,316) and `handleToListing` (~779) wholesale and calls `canonicalizeShopifyCdnUrl` (a `new URL()` parse) on *every* item image and *every* listing image *every* action, though only ≤4 candidate URLs can match — ≈0.9 M redundant URL parses.

**Recommendations (no behavior change, cold-start/replay only — no live or correctness impact):**
1. Memoize `canonicalizeShopifyCdnUrl` (pure string→string; same URLs re-parsed 703×). Smallest change, likely an order-of-magnitude win.
2. Short-circuit the map clones when nothing matches `sourceSet`.
3. (Optional) maintain a reverse `canonicalUrl → ids` index.

Estimated: #1+#2 should take replay from ~82 s toward ~22 s. No code change in this PR — analysis only, per request.

## Test plan

- [x] Profiler reproducer verified against `../production-backup-apr-25/firestore-export.json`
- [x] Docs-only; pre-commit (check + full unit suite) and pre-push (live + 26 E2E specs) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)