### PR TITLE
perf(root-reducer): memoize Shopify CDN URL canonicalization

### DIFF
--- a/src/lib/root-reducer.ts
+++ b/src/lib/root-reducer.ts
@@ -381,7 +381,31 @@ const trimString = (value: unknown): string =>
 const isShopifyCdnUrl = (value: string): boolean =>
   value.includes("cdn.shopify.com");
 
-const canonicalizeShopifyCdnUrl = (raw: string): string => {
+// These three are pure string->string transforms but each runs a
+// `new URL()` parse. During a full replay the photos/shopify_cdn_uploaded
+// handler calls them on every inventory item image and every listing
+// image on every action, re-parsing the same URLs ~10^6 times (see
+// docs/investigations/REPLAY_PERFORMANCE.md). Memoize on the raw input
+// string: same input always yields the same output, so the cache cannot
+// change behavior. A bounded cap prevents unbounded growth in the
+// long-lived app (replay distinct-URL counts are well under the cap).
+const SHOPIFY_URL_MEMO_CAP = 50_000;
+const memoizeStringFn = (
+  fn: (raw: string) => string,
+): ((raw: string) => string) => {
+  const cache = new Map<string, string>();
+  return (raw: string): string => {
+    const key = typeof raw === "string" ? raw : "";
+    const hit = cache.get(key);
+    if (hit !== undefined) return hit;
+    const out = fn(raw);
+    if (cache.size >= SHOPIFY_URL_MEMO_CAP) cache.clear();
+    cache.set(key, out);
+    return out;
+  };
+};
+
+const canonicalizeShopifyCdnUrl = memoizeStringFn((raw: string): string => {
   const value = trimString(raw);
   if (!value) return "";
   let parsed: URL;
@@ -395,46 +419,50 @@ const canonicalizeShopifyCdnUrl = (raw: string): string => {
   // Normalize repeated slashes in path and preserve search params order as-is.
   parsed.pathname = parsed.pathname.replace(/\/{2,}/g, "/");
   return parsed.toString();
-};
+});
 
-const toDeletedShopifyPathVariant = (rawUrl: string): string => {
-  const value = trimString(rawUrl);
-  if (!value) return "";
-  let parsed: URL;
-  try {
-    parsed = new URL(value);
-  } catch (_) {
-    return "";
-  }
-  if (!parsed.hostname.toLowerCase().includes("cdn.shopify.com")) return "";
-  const normalizedPath = parsed.pathname.replace(/\/{2,}/g, "/");
-  const nextPath = normalizedPath.replace(
-    /^(\/s\/files\/(?:[^/]+\/){4})(?:deleted\/)?files\//i,
-    "$1deleted/files/",
-  );
-  if (nextPath === normalizedPath) return "";
-  parsed.pathname = nextPath.replace(/\/{2,}/g, "/");
-  return parsed.toString();
-};
+const toDeletedShopifyPathVariant = memoizeStringFn(
+  (rawUrl: string): string => {
+    const value = trimString(rawUrl);
+    if (!value) return "";
+    let parsed: URL;
+    try {
+      parsed = new URL(value);
+    } catch (_) {
+      return "";
+    }
+    if (!parsed.hostname.toLowerCase().includes("cdn.shopify.com")) return "";
+    const normalizedPath = parsed.pathname.replace(/\/{2,}/g, "/");
+    const nextPath = normalizedPath.replace(
+      /^(\/s\/files\/(?:[^/]+\/){4})(?:deleted\/)?files\//i,
+      "$1deleted/files/",
+    );
+    if (nextPath === normalizedPath) return "";
+    parsed.pathname = nextPath.replace(/\/{2,}/g, "/");
+    return parsed.toString();
+  },
+);
 
-const toNonDeletedShopifyPathVariant = (rawUrl: string): string => {
-  const value = trimString(rawUrl);
-  if (!value) return "";
-  let parsed: URL;
-  try {
-    parsed = new URL(value);
-  } catch (_) {
-    return "";
-  }
-  if (!parsed.hostname.toLowerCase().includes("cdn.shopify.com")) return "";
-  const nextPath = parsed.pathname.replace(
-    /^(\/s\/files\/(?:[^/]+\/){4})deleted\/files\//i,
-    "$1files/",
-  );
-  if (nextPath === parsed.pathname) return "";
-  parsed.pathname = nextPath.replace(/\/{2,}/g, "/");
-  return parsed.toString();
-};
+const toNonDeletedShopifyPathVariant = memoizeStringFn(
+  (rawUrl: string): string => {
+    const value = trimString(rawUrl);
+    if (!value) return "";
+    let parsed: URL;
+    try {
+      parsed = new URL(value);
+    } catch (_) {
+      return "";
+    }
+    if (!parsed.hostname.toLowerCase().includes("cdn.shopify.com")) return "";
+    const nextPath = parsed.pathname.replace(
+      /^(\/s\/files\/(?:[^/]+\/){4})deleted\/files\//i,
+      "$1files/",
+    );
+    if (nextPath === parsed.pathname) return "";
+    parsed.pathname = nextPath.replace(/\/{2,}/g, "/");
+    return parsed.toString();
+  },
+);
 
 // Root reducer to handle full state hydration and Event Sourcing Orchestration
 export const rootReducer = (


### PR DESCRIPTION
## Summary

Implements recommendation #1 from `docs/investigations/REPLAY_PERFORMANCE.md`.

`canonicalizeShopifyCdnUrl` (and the deleted/non-deleted path variants) are pure `string → string` transforms that each run a `new URL()` parse. The `photos/shopify_cdn_uploaded` handler calls them on every inventory item image and every listing image on every action — re-parsing the same ~1,316 URLs ≈10⁶ times across a full replay (that handler was 74% of an 81.8 s replay).

Wrapped all three in a bounded module-level `Map` memo (cap 50k, cleared wholesale on overflow). Same input always yields the same output, so the cache **cannot change behavior**.

## Before / after (full Apr 25 replay, 24,799 actions, same machine, plain replay)

| | Run A | Run B |
|---|---|---|
| **BEFORE** (main) | 81.44 s | 81.36 s |
| **AFTER** (memoized) | 18.33 s / 18.71 s | 19.09 s |

**≈ 4.4× faster — ~81.4 s → ~18.7 s, ~62 s saved** (slightly better than the investigation's ~22 s estimate).

## State-identity verification

A determinism-robust hash (sorted item images + `shopifyUrlToDriveUrl` + per-listing sorted image-URL sets) is **identical on main and branch across repeated runs** (`fd6829a7…` on all four runs). The memoization is provably state-neutral.

Note: a naive full-state hash differed run-to-run *on both main and branch* — a **preexisting** replay nondeterminism from `crypto.randomUUID()` ids minted in listing/variant orchestration. It is unrelated to and untouched by this change (the memoized URL functions don't influence those ids). Flagging it as a separate future item; out of scope here.

## Scope

Cold-start / replay / audit-page only — in live operation these functions are called rarely. No correctness or live impact.

## Test plan

- [x] `bun run check` clean
- [x] Before/after timed replay (numbers above) + determinism-robust state hash identical main vs branch
- [x] Pre-commit (check + full unit suite) and pre-push (live fixtures + 26 non-live E2E specs) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)