### PR TITLE
perf(approve_proposal): batch non-subtype field writes (update_fields)

### DIFF
--- a/docs/investigations/REPLAY_PERFORMANCE.md
+++ b/docs/investigations/REPLAY_PERFORMANCE.md
@@ -161,3 +161,83 @@ Look at: "Wall time per 1000-action bucket" (21k–23k spike),
 "State size growth" (flat ⇒ not O(n)-over-growth), and "30 slowest
 individual actions" (all `photos/shopify_cdn_uploaded`, indices
 21.5k–23k).
+
+---
+
+## Addendum — post-memoization re-profile (PR #129 merged)
+
+After memoizing the Shopify-CDN URL transforms, the bottleneck moved.
+Re-profiled on `main` (memoization merged):
+
+```
+Total replay: 81.8 s  →  18.2 s   (4.5x; the 21k–23k spike is gone)
+photos/shopify_cdn_uploaded: 60,467 ms (74%)  →  538 ms (~3%)
+```
+
+The originally-recommended #2 (short-circuit the clones) and #3
+(reverse index) are **retired**: with the handler down to 538 ms,
+removing it entirely would save <3% of an 18 s replay while adding
+branching to a hot reducer. Memoization captured ~95% of the win.
+
+New #1 cost: **`listingCreation/approve_proposal` — 4,293 ms across
+280 actions (~23% of the remaining replay), ~15 ms/action, 54 ms
+worst case.**
+
+### What is wrong with approve_proposal
+
+Phase-timed instrumentation on the real backup:
+
+```
+field-update loop : 3,789 ms  (99%)
+buildDraftListingImages : 6 ms
+section 4.5 (handle reconcile) : 19 ms
+```
+
+Splitting the field loop further:
+
+```
+inventory reducer calls : 3,629 ms  over ~3,288 calls (~1.1 ms each)
+  - non-subtype fields : 3,058 ms
+  - subtype field      :   587 ms
+listings reducer calls  :   164 ms
+  - skippable (non handle/description) : only 25 ms
+```
+
+So it is **not** the subtype rename and **not** the listings reducer.
+The defect is *dispatch fan-out*: the orchestrator emits one
+`update_field` per (variant × ~6 fields), driving ~3,288 separate
+Immer `produce` passes over the large inventory slice for 280
+approvals. Per-call cost is uniform (~1.1 ms) regardless of field.
+
+### Fix
+
+Added `update_fields` (batched, non-re-keying) to the inventory slice,
+exactly mirroring the non-subtype `update_field` branch (same field
+write + same history entry, per entry, in order). `approve_proposal`
+now applies all non-subtype fields for a variant in **one** inventory
+produce; the `listings` reducer is invoked only for `handle` /
+`description` (the only fields it consumes — all others were verified
+no-ops), in original order; `subtype` stays a separate last
+`update_field` (it re-keys), with its rekey block unchanged.
+
+Inventory produces/variant: ~6 → 2.
+
+### Result (full Apr 25 replay, atop the merged memoization)
+
+```
+approve_proposal total : 4,293 ms  →  1,931 ms   (2.2x; 7.83 → 3.52 ms/variant)
+full replay            : ~18.7 s   →  ~16.1 s     (~14% faster)
+```
+
+**Behavior proven identical:** a determinism-robust full-state hash
+(sorted idToItem incl. image/price/handle/pos/desc, full idToHistory
+entries, idToHandle, per-listing sorted image-URL sets) is byte-
+identical on `main` and the fix branch across repeated runs
+(`15bfb5c4…`). Unit test `tests/unit/update-fields-equivalence.test.ts`
+pins `update_fields ≡ sequential update_field`. (The preexisting
+`crypto.randomUUID` replay nondeterminism — see PR #129 — is excluded
+from the hash and remains a separate future item.)
+
+Beyond this, remaining replay cost is broadly distributed
+(`photos/complete_upload`/`complete_edit` ≈ 1.1–1.3 ms over thousands
+of actions) — diminishing returns; no further single hotspot.

--- a/src/lib/inventory.ts
+++ b/src/lib/inventory.ts
@@ -158,6 +158,21 @@ export const update_field = createAction<{
   from: string | number;
   to: string | number;
 }>("update_field");
+// Batched, non-re-keying field writes for a single item. Semantically
+// identical to dispatching update_field once per entry in order, but in
+// a single Immer produce. Used by the approve_proposal orchestration to
+// collapse ~6 inventory reducer passes/variant into 1 (see
+// docs/investigations/REPLAY_PERFORMANCE.md). "subtype" is intentionally
+// NOT supported here — it re-keys the item and must stay a separate,
+// last update_field.
+export const update_fields = createAction<{
+  id: string;
+  fields: {
+    field: keyof Item;
+    from: string | number;
+    to: string | number;
+  }[];
+}>("update_fields");
 export const new_order = createAction<{
   orderID: string;
   date: Date;
@@ -1832,6 +1847,50 @@ export const inventory = createReducer(initialState, (r) => {
     } else {
       console.warn(
         `Skipping update_field for missing item: ${itemKey}`,
+        action.payload,
+      );
+    }
+  });
+  r.addCase(update_fields, (state, action) => {
+    const itemKey = canonicalizeInventoryItemKey(action.payload.id);
+    if (state.idToItem[itemKey]) {
+      const timestamp = (action as any).timestamp;
+      let val = 0;
+      let creationDate = "Invalid Date";
+      if (timestamp) {
+        if (timestamp.seconds) {
+          val = new Date(timestamp.seconds * 1000).getTime();
+        } else if (typeof timestamp === "number") {
+          val = timestamp;
+        }
+        if (val > 0) {
+          creationDate = new Date(val).toLocaleString("en", {
+            year: "numeric",
+            month: "short",
+            day: "numeric",
+          });
+        }
+      }
+      // Mirror the non-subtype branch of update_field exactly, per entry,
+      // in dispatch order — same field write + same history entry.
+      for (const { field, from, to: incomingValue } of action.payload.fields) {
+        (state.idToItem[itemKey] as any)[field] =
+          field === "qty" ||
+          field === "shipped" ||
+          field === "price" ||
+          field === "cost" ||
+          field === "weight"
+            ? Number(incomingValue)
+            : incomingValue;
+        state.idToHistory[itemKey].push({
+          date: creationDate,
+          desc: `${field} changed from ${from} to ${incomingValue}`,
+          val,
+        });
+      }
+    } else {
+      console.warn(
+        `Skipping update_fields for missing item: ${itemKey}`,
         action.payload,
       );
     }

--- a/src/lib/root-reducer.ts
+++ b/src/lib/root-reducer.ts
@@ -6,6 +6,7 @@ import {
   type BulkImportItem,
   type Item,
   update_field,
+  update_fields,
   new_order,
   package_item,
   split_inventory_item,
@@ -2003,7 +2004,56 @@ export const rootReducer = (
         if (v.option1Value)
           fields.push({ field: "subtype", value: v.option1Value });
 
-        fields.forEach((f) => {
+        // Collapse the per-(variant×field) reducer fan-out (the dominant
+        // approve_proposal cost — see docs/investigations/
+        // REPLAY_PERFORMANCE.md): apply all non-subtype fields in ONE
+        // inventory produce via update_fields. The listings reducer only
+        // consumes handle/description (all other fields are no-ops there),
+        // so dispatch just those to listings, in original field order, to
+        // preserve applyHandleUpdate / title-sync behaviour exactly.
+        // subtype stays a separate, last update_field because it re-keys.
+        const nonSubtype = fields.filter((f) => f.field !== "subtype");
+        const subtypeField = fields.find((f) => f.field === "subtype");
+
+        if (nonSubtype.length > 0) {
+          const batchAction = inheritTimestamp({
+            ...update_fields({
+              id: currentItemId,
+              fields: nonSubtype.map((f) => ({
+                field: f.field,
+                from: "",
+                to: f.value,
+              })),
+            }),
+            _ephemeral: true,
+          });
+          nextState = {
+            ...nextState,
+            inventory: inventory(nextState.inventory, batchAction),
+          };
+          logger(batchAction, nextState, action._timestamp);
+
+          for (const f of nonSubtype) {
+            if (f.field !== "handle" && f.field !== "description") continue;
+            const listingAction = inheritTimestamp({
+              ...update_field({
+                id: currentItemId,
+                field: f.field,
+                from: "",
+                to: f.value,
+              }),
+              _ephemeral: true,
+            });
+            nextState = {
+              ...nextState,
+              listings: listings(nextState.listings, listingAction),
+            };
+            logger(listingAction, nextState, action._timestamp);
+          }
+        }
+
+        if (subtypeField) {
+          const f = subtypeField;
           const itemBeforeUpdate = nextState.inventory.idToItem[currentItemId];
           const janBeforeUpdate =
             itemBeforeUpdate?.janCode ||
@@ -2026,36 +2076,35 @@ export const rootReducer = (
           };
           logger(updateAction, nextState, action._timestamp);
 
-          // Subtype updates can re-key inventory IDs (jan+subtype). Keep local references in sync
-          // so downstream idToHandle aggregation includes renamed keys (required for subtype pills).
-          if (f.field === "subtype") {
-            const subtype = (f.value as string)?.trim() || "";
-            const baseJan = janBeforeUpdate;
-            const renamedItemId = makeInventoryItemKey(baseJan, subtype);
-            if (
-              renamedItemId &&
-              renamedItemId !== currentItemId &&
-              nextState.inventory.idToItem[renamedItemId]
-            ) {
-              const listingState = nextState.listings;
-              const nextIdToHandle = { ...listingState.idToHandle };
-              const mappedHandle = nextIdToHandle[currentItemId] || finalHandle;
-              nextIdToHandle[renamedItemId] = mappedHandle;
-              delete nextIdToHandle[currentItemId];
+          // Subtype updates re-key inventory IDs (jan+subtype). Keep local
+          // references in sync so downstream idToHandle aggregation
+          // includes renamed keys (required for subtype pills).
+          const subtype = (f.value as string)?.trim() || "";
+          const baseJan = janBeforeUpdate;
+          const renamedItemId = makeInventoryItemKey(baseJan, subtype);
+          if (
+            renamedItemId &&
+            renamedItemId !== currentItemId &&
+            nextState.inventory.idToItem[renamedItemId]
+          ) {
+            const listingState = nextState.listings;
+            const nextIdToHandle = { ...listingState.idToHandle };
+            const mappedHandle = nextIdToHandle[currentItemId] || finalHandle;
+            nextIdToHandle[renamedItemId] = mappedHandle;
+            delete nextIdToHandle[currentItemId];
 
-              nextState = {
-                ...nextState,
-                listings: {
-                  ...listingState,
-                  idToHandle: nextIdToHandle,
-                },
-              };
+            nextState = {
+              ...nextState,
+              listings: {
+                ...listingState,
+                idToHandle: nextIdToHandle,
+              },
+            };
 
-              currentItemId = renamedItemId;
-              variantIdToItemId.set(v.id, renamedItemId);
-            }
+            currentItemId = renamedItemId;
+            variantIdToItemId.set(v.id, renamedItemId);
           }
-        });
+        }
       });
 
       // 4.5 Ensure ALL merged items point to the final handle in listings state

--- a/tests/unit/update-fields-equivalence.test.ts
+++ b/tests/unit/update-fields-equivalence.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { rootReducer } from "$lib/root-reducer";
+import {
+  update_field,
+  update_fields,
+  update_item,
+  type Item,
+} from "$lib/inventory";
+
+// update_fields must be byte-identical to dispatching update_field once
+// per entry, in order (same idToItem write + same idToHistory entries).
+// This underpins the approve_proposal fan-out collapse in root-reducer
+// (docs/investigations/REPLAY_PERFORMANCE.md).
+
+const TS = { _seconds: 1_700_000_000, _nanoseconds: 0 };
+
+function seed(): any {
+  let s = rootReducer(undefined, { type: "@@INIT" });
+  const item: Item = {
+    janCode: "4900000000001",
+    subtype: "Blue",
+    description: "Seed",
+    hsCode: "",
+    image: "",
+    qty: 5,
+    pieces: 1,
+    shipped: 0,
+    creationDate: "",
+    timestamp: 0,
+  };
+  s = rootReducer(s, {
+    ...update_item({ id: "4900000000001Blue", item }),
+    timestamp: TS,
+  } as any);
+  return s;
+}
+
+const FIELDS: {
+  field: keyof Item;
+  from: string | number;
+  to: string | number;
+}[] = [
+  { field: "price", from: "", to: 4.5 },
+  { field: "handle", from: "", to: "my-handle-4900000000001" },
+  { field: "description", from: "", to: "Updated Desc" },
+  { field: "image", from: "", to: "https://example.com/a.png" },
+  { field: "imagePosition", from: "", to: 2 },
+];
+
+const ID = "4900000000001Blue";
+
+describe("update_fields ≡ sequential update_field", () => {
+  it("produces identical idToItem and idToHistory", () => {
+    let seq = seed();
+    for (const f of FIELDS) {
+      seq = rootReducer(seq, {
+        ...update_field({ id: ID, field: f.field, from: f.from, to: f.to }),
+        timestamp: TS,
+      } as any);
+    }
+
+    let batch = seed();
+    batch = rootReducer(batch, {
+      ...update_fields({ id: ID, fields: FIELDS }),
+      timestamp: TS,
+    } as any);
+
+    expect(batch.inventory.idToItem[ID]).toEqual(seq.inventory.idToItem[ID]);
+    expect(batch.inventory.idToHistory[ID]).toEqual(
+      seq.inventory.idToHistory[ID],
+    );
+  });
+
+  it("no-ops on a missing item (same as update_field)", () => {
+    let s = seed();
+    const before = JSON.stringify(s.inventory.idToItem);
+    s = rootReducer(s, {
+      ...update_fields({
+        id: "9999999999999Ghost",
+        fields: [{ field: "price", from: "", to: 1 }],
+      }),
+      timestamp: TS,
+    } as any);
+    expect(JSON.stringify(s.inventory.idToItem)).toBe(before);
+  });
+
+  it("applies numeric coercion for qty/price like update_field", () => {
+    let s = seed();
+    s = rootReducer(s, {
+      ...update_fields({
+        id: ID,
+        fields: [
+          { field: "price", from: "", to: "7.25" },
+          { field: "qty", from: "", to: "9" },
+        ],
+      }),
+      timestamp: TS,
+    } as any);
+    expect(s.inventory.idToItem[ID].price).toBe(7.25);
+    expect(s.inventory.idToItem[ID].qty).toBe(9);
+  });
+});


### PR DESCRIPTION
## Summary

After PR #129 (memoization) merged, a re-profile moved the replay bottleneck to **`listingCreation/approve_proposal`** — 4,293 ms across 280 actions (~23% of the now-18 s replay), 15 ms/action avg, 54 ms worst case.

### What is wrong (measured, not guessed)

Phase-timed instrumentation on the Apr 25 backup:

```
field-update loop          : 3,789 ms  (99% of approve_proposal)
buildDraftListingImages    :     6 ms
section 4.5 (handle reconcile): 19 ms
```

Splitting the loop:

```
inventory reducer calls : 3,629 ms over ~3,288 calls (~1.1 ms each, uniform)
  non-subtype fields : 3,058 ms      subtype field : 587 ms
listings reducer calls  :   164 ms   (skippable part only 25 ms)
```

It is **not** the subtype rename and **not** the listings reducer. The defect is **dispatch fan-out**: the orchestrator emits one `update_field` per (variant × ~6 fields), driving ~3,288 separate Immer `produce` passes over the large inventory slice for 280 approvals.

### Fix

New `update_fields` (batched, non-re-keying) action on the inventory slice, mirroring the non-subtype `update_field` branch **exactly** (same field write + same `idToHistory` entry, per entry, in order). `approve_proposal` now applies all non-subtype fields for a variant in **one** inventory produce; `listings` is invoked only for `handle`/`description` (the only fields it consumes — all others verified no-ops), in original order; `subtype` stays a separate last `update_field` with its rekey block unchanged. Inventory produces/variant: ~6 → 2.

### Behavior proven identical

Determinism-robust full-state hash — sorted `idToItem` (incl. image/price/handle/imagePosition/description), **full `idToHistory` entries**, `idToHandle`, per-listing sorted image-URL sets — is **byte-identical on `main` vs this branch across repeated runs** (`15bfb5c4…`). New unit test `tests/unit/update-fields-equivalence.test.ts` pins `update_fields ≡ sequential update_field` (incl. missing-item no-op and numeric coercion). (The preexisting `crypto.randomUUID` replay nondeterminism from PR #129 is excluded from the hash and remains a separate future item.)

### Result (full Apr 25 replay, atop merged memoization)

```
approve_proposal : 4,293 ms → 1,931 ms   (2.2×; 7.83 → 3.52 ms/variant)
full replay      : ~18.7 s  → ~16.1 s     (~14%)
```

Investigation recommendations #2/#3 are formally **retired** in the doc addendum (memoization already captured ~95% of the CDN-handler win); remaining replay cost is broadly distributed with no further single hotspot.

## Test plan

- [x] `bun run check` clean
- [x] `tests/unit/update-fields-equivalence.test.ts` — equivalence, no-op, coercion
- [x] Determinism-robust full-replay state hash identical main vs branch (repeated runs) + before/after timing
- [x] Pre-commit (check + full unit suite) and pre-push (live fixtures + 26 non-live E2E specs, incl. listing-creation/approve flow) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)