### PR TITLE
fix(order-import): carry supplier cost onto NEW inventory items

### DIFF
--- a/src/lib/root-reducer.ts
+++ b/src/lib/root-reducer.ts
@@ -351,6 +351,11 @@ const mapOrderToInventory = (importItem: any): Item => {
     creationDate: "Unknown",
     timestamp: 0,
     price: importItem.price,
+    // Order-import parses supplier cost from the CSV (unit price (yen)),
+    // but this mapper previously dropped it, so every order-import-created
+    // item lost its cost — the largest SKU-review COST-exception
+    // bucket. See docs/investigations/COST_EXCEPTIONS.md.
+    cost: importItem.cost,
     weight: importItem.weight,
     countryOfOrigin: importItem.countryOfOrigin,
   };

--- a/tests/unit/order-import-cost.test.ts
+++ b/tests/unit/order-import-cost.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { rootReducer } from "$lib/root-reducer";
+import {
+  start_session,
+  append_raw_rows,
+  import_batch,
+} from "$lib/order-import-slice";
+
+// Regression for docs/investigations/COST_EXCEPTIONS.md bucket A:
+// mapOrderToInventory previously dropped `cost`, so order-import-created
+// NEW items lost the supplier cost parsed from "unit price (yen)".
+
+const TS = { _seconds: 1_700_000_000, _nanoseconds: 0 };
+const JAN = "4542804199999";
+
+// Header is the first appended row (no set_header in production flow).
+const CSV = [
+  "Bar-Code No.,Product name,Total PCS,UNIT PRICE (YEN)",
+  `${JAN},Widget Deluxe,12,JPY 62 `,
+].join("\n");
+
+describe("order import populates cost on NEW items", () => {
+  it("carries supplier unit price (yen) onto the created inventory item", () => {
+    let s = rootReducer(undefined, { type: "@@INIT" });
+    s = rootReducer(s, {
+      ...start_session({ id: "f1", name: "supplier.csv" }),
+      timestamp: TS,
+    } as any);
+    s = rootReducer(s, {
+      ...append_raw_rows({ rawRows: CSV, done: true }),
+      timestamp: TS,
+    } as any);
+    s = rootReducer(s, {
+      ...import_batch({ filter: "NEW" }),
+      timestamp: TS,
+    } as any);
+
+    const item = s.inventory.idToItem[JAN];
+    expect(item).toBeDefined();
+    expect(item.qty).toBe(12);
+    expect(item.cost).toBe(62);
+  });
+});


### PR DESCRIPTION
## Summary

Implements **fix A** from `docs/investigations/COST_EXCEPTIONS.md` (PR #132).

`mapOrderToInventory` (`src/lib/root-reducer.ts`) built order-import NEW items copying `price`/`weight`/`countryOfOrigin` but **omitted `cost`**. The order parser correctly extracts cost from the CSV `unit price (yen)` column, but every order-import-created item lost it — the **largest SKU-Review COST-exception bucket** (251 of 497). Traced JAN `4542804127539`: CSV `"JPY 62 "` → parsed `62` → item created `cost=undefined`.

One-field fix: add `cost: importItem.cost` to the mapper.

## Before / after — full inventory dump, `../production-backup-may-16` (29,742 actions)

- keys **1317 → 1317** (0 added/removed)
- **267 items changed; the only field that changed across all of them is `cost`**
- **0 items with any non-cost field change**; all 267 are `None → real supplier cost` (e.g. 62, 140 JPY); **0 regressions**
- SKU-Review **COST exceptions: 497 → 246 (−251)**
- total items with exceptions: **527 → 280**

The diff *is* the recovery — purely populating the cost the supplier CSV already provided, nothing else moved.

## Test plan

- [x] `bun run check` clean
- [x] New `tests/unit/order-import-cost.test.ts` — drives the order-import NEW path (`start_session` → `append_raw_rows` → `import_batch NEW`) and asserts the created item carries `cost`
- [x] Before/after full inventory dump shows only `cost` changes, 0 collateral, 0 regressions
- [x] Pre-commit (check + full unit suite) and pre-push (live fixtures + 26 non-live E2E specs) — all green

Remaining COST work (separate): bucket B (63 — broaden the strict cost-header match to per-*unit* columns) and C/D (183 — genuine data gaps, not code-fixable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)