### PR TITLE
fix(order-import): derive per-unit cost from line total (COST bucket B)

### DIFF
--- a/src/lib/order-import-slice.ts
+++ b/src/lib/order-import-slice.ts
@@ -116,6 +116,59 @@ const parseNumberish = (value: string | undefined): number | undefined => {
   return Number.isFinite(parsed) ? parsed : undefined;
 };
 
+const cleanMoney = (value: string | undefined): number | undefined => {
+  if (!value) return undefined;
+  const n = parseFloat(value.replace(/[^0-9.]/g, ""));
+  return Number.isFinite(n) ? n : undefined;
+};
+
+// See docs/investigations/COST_EXCEPTIONS.md (bucket B).
+const resolveSupplierCost = (row: any): number | undefined => {
+  // 1. Historical primary — preserve exact prior behaviour/value.
+  const primary = cleanMoney(row["unit price (yen)"]);
+  if (primary !== undefined) return primary;
+
+  // 2. Other explicit per-unit price columns.
+  const altPerUnit = cleanMoney(
+    getValueByHeaders(row, [
+      (h) => h === "unit price (jpy)",
+      (h) => h === "unit price jpy",
+      (h) => h === "list price",
+      (h) =>
+        h.includes("unit price") && (h.includes("yen") || h.includes("jpy")),
+    ]),
+  );
+  if (altPerUnit !== undefined) return altPerUnit;
+
+  // 3. Derive per-unit from a line total when no per-unit column
+  //    exists: total / (pieces-per-unit * units ordered).
+  const total = cleanMoney(
+    getValueByHeaders(row, [
+      (h) => h === "total wholesale amount yen",
+      (h) => h.includes("total wholesale amount") && h.includes("yen"),
+    ]),
+  );
+  if (total === undefined) return undefined;
+  const pcs = parseInt(
+    getValueByHeaders(row, [
+      (h) => /order\s*q'?ty/.test(h) && !h.includes("unit"),
+      (h) => h === "total pcs",
+      (h) => h === "qty",
+    ]) || "0",
+    10,
+  );
+  const units = parseInt(
+    getValueByHeaders(row, [
+      (h) => /order\s*q'?ty/.test(h) && h.includes("unit"),
+      (h) => h === "order q'ty unit",
+    ]) || "0",
+    10,
+  );
+  const denom = pcs * units;
+  if (!Number.isFinite(denom) || denom <= 0) return undefined;
+  return total / denom;
+};
+
 const mapImportItem = (row: any): ImportItem => {
   const janCode = (
     row["jan code"] ||
@@ -167,10 +220,15 @@ const mapImportItem = (row: any): ImportItem => {
     qty,
     carton: row["carton number"] || row["carton"] || "",
     hsCode: findHSCode(row),
-    // Map CSV 'unit price (yen)' (supplier cost) to 'cost'. Strict match required.
-    cost: row["unit price (yen)"]
-      ? parseFloat(row["unit price (yen)"].replace(/[^0-9.]/g, ""))
-      : undefined,
+    // Supplier cost. Resolution order (see docs/investigations/
+    // COST_EXCEPTIONS.md, bucket B):
+    //  1. The historical primary column `unit price (yen)` — parsed
+    //     EXACTLY as before so files that have it are byte-identical.
+    //  2. Other per-UNIT price columns (jpy aliases, list price).
+    //  3. Derived: when only a line TOTAL is given (e.g. the Kanegen
+    //     export has `Total Wholesale Amount YEN` and no per-unit
+    //     column), cost = total / (Order Q'ty PCS * Order Q'ty Unit).
+    cost: resolveSupplierCost(row),
     price: undefined,
     weight,
     countryOfOrigin: countryOfOrigin || undefined,

--- a/tests/unit/order-import-cost-derived.test.ts
+++ b/tests/unit/order-import-cost-derived.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { rootReducer } from "$lib/root-reducer";
+import {
+  start_session,
+  append_raw_rows,
+  import_batch,
+} from "$lib/order-import-slice";
+
+// docs/investigations/COST_EXCEPTIONS.md bucket B: some supplier CSVs
+// (the Kanegen export) have no per-unit price column, only a line
+// `Total Wholesale Amount YEN`. Per-unit cost is derived as
+//   total / (Order Q'ty PCS * Order Q'ty Unit).
+// The historical `unit price (yen)` column must still win when present.
+
+const TS = { _seconds: 1_700_000_000, _nanoseconds: 0 };
+
+function runCsv(csv: string) {
+  let s = rootReducer(undefined, { type: "@@INIT" });
+  s = rootReducer(s, {
+    ...start_session({ id: "f", name: "supplier.csv" }),
+    timestamp: TS,
+  } as any);
+  s = rootReducer(s, {
+    ...append_raw_rows({ rawRows: csv, done: true }),
+    timestamp: TS,
+  } as any);
+  s = rootReducer(s, {
+    ...import_batch({ filter: "NEW" }),
+    timestamp: TS,
+  } as any);
+  return s.inventory.idToItem;
+}
+
+describe("order-import derived supplier cost (bucket B)", () => {
+  it("derives cost = Total Wholesale Amount YEN / (PCS * Unit) when no per-unit column", () => {
+    const JAN = "4952270317561";
+    const csv = [
+      "JAN code,Country of Origin,Product name（product number）,Order Q'ty Unit,Order Q'ty PCS,Total Wholesale Amount YEN",
+      `${JAN},Japan,LT725 Kalita Black,4,20,"4,700"`,
+    ].join("\n");
+    const inv = runCsv(csv);
+    expect(inv[JAN]).toBeDefined();
+    // 4700 / (20 * 4) = 58.75
+    expect(inv[JAN].cost).toBeCloseTo(58.75, 5);
+  });
+
+  it("still prefers an explicit unit price (yen) over the derived total", () => {
+    const JAN = "4900000000123";
+    const csv = [
+      "JAN code,Order Q'ty Unit,Order Q'ty PCS,Total Wholesale Amount YEN,UNIT PRICE (YEN)",
+      `${JAN},4,20,"4,700",JPY 99 `,
+    ].join("\n");
+    const inv = runCsv(csv);
+    expect(inv[JAN].cost).toBe(99);
+  });
+
+  it("leaves cost undefined when only a total but no usable PCS*Unit", () => {
+    const JAN = "4900000000999";
+    const csv = [
+      "JAN code,Order Q'ty Unit,Order Q'ty PCS,Total Wholesale Amount YEN",
+      `${JAN},0,0,"4,700"`,
+    ].join("\n");
+    const inv = runCsv(csv);
+    expect(inv[JAN]).toBeDefined();
+    expect(inv[JAN].cost).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Implements **bucket B** from `docs/investigations/COST_EXCEPTIONS.md`. The Kanegen supplier export (`Kanegan #3 … Normalised Data with HS Code.csv`) has **no per-unit price column** — only a line `Total Wholesale Amount YEN`. `cost` was the only parsed field still using a strict single-header match (`unit price (yen)`), so all of that file's rows yielded `cost: undefined`.

New `resolveSupplierCost(row)` resolves in order:
1. **`unit price (yen)`** — parsed *exactly* as before (files that have it are byte-identical; zero regression).
2. Other explicit per-unit columns (`unit price (jpy)` / `jpy` aliases, `list price`).
3. **Derived** when only a line total exists: `cost = Total Wholesale Amount YEN / (Order Q'ty PCS × Order Q'ty Unit)` — the owner's formula, e.g. `4,700 / (20×4) = 58.75` JPY/unit. Guards divide-by-zero / non-finite.

## Before / after — full inventory dump, `../production-backup-may-16`

- keys **1317 → 1317** (0 added/removed)
- **71 items changed; the only field changed across all of them is `cost`**; 0 non-cost changes
- **66 gained** cost (None → derived)
- **5 RE-VALUED** — ⚠️ **please verify with the owner**: an earlier per-unit cost is overwritten by a later total-only order's derived cost via the *existing* MATCH "latest order wins" path:

| key | before | after |
|---|--:|--:|
| `4902778028179Black` | 282.7 | 243 |
| `4902778028186Silver` | 282.7 | 243 |
| `4902778028216` | 282.5 | 243 |
| `4952270287321Cat in Mug` | 194 | 97 |
| `4977564637699Green` | 385 | 201 |

- SKU-Review **COST exceptions: 246 → 183 (−63)**; total exceptions **280 → 217**

Cumulative with fix A (#133): COST **497 → 183**, total exceptions **527 → 217**. The remaining ~183 are buckets C/D (genuine supplier-data gaps — not code-fixable).

## Test plan

- [x] `bun run check` clean
- [x] `tests/unit/order-import-cost-derived.test.ts` — derive math, `unit price (yen)` precedence, zero-denominator guard
- [x] Before/after full inventory dump — only `cost` changes, 0 collateral
- [x] Pre-push (live + 26 non-live E2E) green. (First attempt hit the known intermittent `waitForAppReady` loading-overlay flake on spec 015 under full-suite load — verified 015 passes cleanly in isolation and again on the green pre-push run; orthogonal to this order-import-only change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)