### PR TITLE
docs: design — received inventory + weighted moving-average cost

### DIFF
--- a/docs/investigations/DESIGN_RECEIVED_INVENTORY_AND_MOVING_AVERAGE_COST.md
+++ b/docs/investigations/DESIGN_RECEIVED_INVENTORY_AND_MOVING_AVERAGE_COST.md
@@ -1,0 +1,183 @@
+# Design — Received Inventory + Weighted Moving-Average Cost
+
+Follows `COST_SHOULD_BE_MOVING_AVERAGE.md` (PR #135). Concrete design
++ sequenced, independently-shippable milestones. Decision taken:
+**option (a)** — order imports carry a received date; missing/historical
+dates fall back to the action timestamp and are **flagged for review**;
+a new route lets us see and **edit** received dates so past imports can
+be corrected to the true receipt date.
+
+## Goals
+
+1. Inventory `cost` is a **perpetual weighted moving-average**, not
+   last-write-wins.
+2. Cost changes are driven by **receipts dated when goods were
+   received**, not when the order CSV was processed. Editing a
+   received date re-derives the average deterministically.
+3. Every cost change writes a structured **audit entry to item
+   history** (old→new, lot qty/cost, formula, source).
+4. Operators can see/repair received dates (**/received-inventory**)
+   and supply cost for JANs with no received-order coverage via a
+   **manual dated-cost flow** surfaced on an exceptions page.
+
+## Hard constraints (must respect)
+
+- **Replay determinism.** Reducers must not read wall-clock
+  (`scripts/check-no-date-now-in-reducers.mjs` enforces this). Every
+  date the algorithm uses must come from **action payloads**, never
+  `Date.now()`.
+- **Event-sourced.** All new state transitions are broadcast actions,
+  replayable; conclusions logged to `idToHistory`.
+- **Schema bump.** New persisted state (cost-lot ledger, received-order
+  registry) is a non-backward-compatible shape change ⇒ bump
+  `CURRENT_SCHEMA_VERSION` (4→5) so hydrated clients discard the
+  snapshot and re-derive via full replay. Cold replay is ~16 s after
+  the perf work (PRs #129/#130), acceptable.
+- **Validation.** The "before/after diff = 0" guarantee no longer
+  applies (cost changes broadly by design). Validation = hand-computed
+  expected averages for the 5 known multi-lot items + a sample of
+  other multi-order JANs, the SKU/cost CLI deltas, a determinism hash,
+  and pre-push.
+
+## Data model
+
+### Received-order registry (new `inventory` sub-state)
+
+```
+receivedOrders: {
+  [orderKey: string]: {
+    orderKey: string;          // stable id (orderImport session id)
+    name: string;              // session/file name
+    receivedAt: number;        // ms; the authoritative receipt date
+    dateSource: "ui" | "action-timestamp" | "manual";
+    needsReview: boolean;      // true when dateSource !== "ui"
+    importedAtMs: number;      // processing time (for display only)
+  }
+}
+```
+
+### Cost-lot ledger (per item)
+
+```
+costLots: {
+  [itemKey: string]: Array<{
+    receivedAt: number;        // sort key (NOT processing time)
+    qty: number;               // units received in this lot
+    unitCost: number;          // per-unit supplier cost for the lot
+    source: string;            // orderKey | "manual" | "shopify" | "update_field"
+    actionId?: string;
+  }>
+}
+```
+
+`cost` (and an `onHandValue`) are **derived**, never mutated forward:
+a pure fold over `costLots[itemKey]` **sorted by `receivedAt`**,
+interleaved with shipments by date. Re-running the fold after any lot
+insert/date-edit yields the temporally-correct average — this is what
+makes "process last year's order today, affect the past" work.
+
+## Algorithm — perpetual weighted moving average
+
+Fold events for an item in `receivedAt`/saleDate order:
+
+- **Receipt** `(qtyIn, costIn)`:
+  - if `onHandQty <= 0` **or** current `avgCost` is 0/unknown →
+    `avgCost = costIn` (establish/overwrite basis, per the explicit
+    rule "if cost was previously 0, overwrite").
+  - else `avgCost = (onHandQty·avgCost + qtyIn·costIn) /
+    (onHandQty + qtyIn)`.
+  - `onHandQty += qtyIn`.
+- **Shipment/sale** `qtyOut`: `onHandQty -= qtyOut`; `avgCost`
+  unchanged; COGS = `qtyOut·avgCost` (recorded, not yet surfaced).
+- **Archive / zeroing** (`archive_inventory`): `onHandQty = 0`,
+  basis reset; next receipt re-establishes `avgCost`.
+- **Manual cost adjustment**: explicit `avgCost` correction (audited),
+  not a receipt.
+
+Worked checks (must match in tests):
+- User example: 10@¥100, sell 2, 10@¥75 ⇒ `(8·100 + 10·75)/18 =
+  ¥86.11`.
+- `4902778028179Black`: lot1 ¥282.70 (Order 1) + lot2 ¥243 (Order 5)
+  ⇒ receipt-weighted ≈ ¥262.85 (exact depends on interleaved sales;
+  the date-ordered fold computes the true figure).
+
+## Received-date sourcing (option a)
+
+- The order-import UI flow gains a **received-date input**; the
+  emitted action carries `receivedAt` + `dateSource:"ui"`.
+- **Historical/replayed** order imports with no `receivedAt` →
+  `receivedAt = importAction effective timestamp`,
+  `dateSource:"action-timestamp"`, `needsReview:true`.
+- `/received-inventory` lists every received order; **edit-date**
+  dispatches `set_received_order_date` (event-sourced) → flips
+  `dateSource:"manual"`, clears `needsReview`, and the cost fold
+  re-derives all affected items' averages (+ audit history entries).
+
+## New routes / actions
+
+- Route **`/received-inventory`**: table of `receivedOrders`
+  (name, receivedAt, source badge, ⚠ needsReview, edit-date).
+- Route **`/cost-exceptions`** (or a tab): JANs with on-hand stock
+  but **no received-order cost lot**; a **manual dated-cost** form →
+  `manual_cost_entry({ itemKey, unitCost, qty, receivedAt, note })`
+  (a synthetic lot; audited).
+- New actions (all event-sourced, in `inventory` slice):
+  `record_received_order`, `set_received_order_date`,
+  `manual_cost_entry`. Order-import NEW/MATCH stop overwriting `cost`
+  and instead append to `costLots` (via the import orchestration).
+
+## Milestones (sequenced, each its own PR, each validated)
+
+**M0 (this doc).** Design + decision (a).
+
+**M1 — Hold/neutralize #134.** Re-land bucket-B *derivation*
+(`Total Wholesale ÷ (PCS×Unit)`) but as a value that flows into the
+lot model, not an overwrite. (If #134 is still open, convert it; else
+follow-up.) Net: stop making the 5 items worse.
+
+**M2 — Cost-lot ledger + moving-average fold (no UI).** Add
+`costLots` state + pure fold; order-import NEW/MATCH and the
+existing cost writers append lots (receivedAt = action timestamp,
+dateSource action-timestamp). Derive `cost` from the fold. Schema
+bump 4→5. Structured audit history on every cost change. Validate vs
+hand-computed 5 + CLI deltas + determinism hash.
+
+**M3 — Received-order registry + `record_received_order`.** Populate
+`receivedOrders` from order-import sessions; `needsReview` for
+action-timestamp dates. No behaviour change to cost yet beyond M2.
+
+**M4 — `/received-inventory` route.** Read-only table first, then
+edit-date (`set_received_order_date`) → re-derived averages + audit.
+E2E coverage.
+
+**M5 — Order-import UI received-date capture.** New imports emit
+`dateSource:"ui"`; no `needsReview`.
+
+**M6 — Cost-exceptions page + `manual_cost_entry`.** Enumerate
+uncovered JANs; manual dated-cost lot; audited. Drives remaining
+SKU-review COST (buckets C/D) toward 0 with real dated data.
+
+Each milestone: before/after on `production-backup-may-16`, the
+SKU/cost CLI, unit tests for the fold (incl. **out-of-received-order
+insertion** = the temporal guarantee), and pre-push.
+
+## Interaction with open PRs
+
+- **#133 (fix A)** — keep/merge; supplies the per-lot cost the ledger
+  consumes.
+- **#134 (fix B)** — **hold**; superseded by M1 (derivation reused as
+  a lot input, not an overwrite).
+- **#135** — rationale; this is its concrete design.
+
+## Open questions for owner
+
+1. Authoritative received date when the supplier CSV lacks one and
+   the operator doesn't know it — best estimate + `needsReview`, or
+   block import?
+2. Are Shopify-import / `update_field` cost writes **corrections**
+   (set avg directly, audited) or ignored once order-lot data exists?
+3. Opening-balance bootstrap for items whose earliest receipts
+   predate any cost data — leave uncosted (exceptions page) until a
+   manual dated entry is supplied? (Recommended.)
+4. COGS/valuation surfacing — out of scope here (the fold computes it;
+   where it's reported is a later design).

--- a/docs/investigations/DESIGN_RECEIVED_INVENTORY_AND_MOVING_AVERAGE_COST.md
+++ b/docs/investigations/DESIGN_RECEIVED_INVENTORY_AND_MOVING_AVERAGE_COST.md
@@ -181,3 +181,39 @@ insertion** = the temporal guarantee), and pre-push.
    manual dated entry is supplied? (Recommended.)
 4. COGS/valuation surfacing — out of scope here (the fold computes it;
    where it's reported is a later design).
+
+---
+
+## Resolution of open questions (code-backed, may-16 backup)
+
+Reproducer: `/tmp/cost-writers.ts` (enumerates update_field cost
+actions; replays and attributes every idToItem cost transition to the
+authoring action type; flags shopify-originated changes).
+
+**Q2 — Shopify / update_field as a cost "correction" path: SPECIOUS.**
+- `update_field` actions with `field === "cost"`: **0** in the entire
+  history. There is no manual cost-edit path to reconcile.
+- `shopify-import-slice.ts` contains no `cost` logic; the Shopify CSV
+  has no cost column; `mapShopifyToInventory` cannot introduce cost.
+- Exactly **one** shopify action (`#3809 shopifyImport/import_batch`)
+  shows cost transitions, all `undefined → <order cost>` (e.g. `→194`
+  = Furukawa LS494 ¥194 from Kanegen Order 3). These are
+  order-import-authored costs being **carried onto the canonical key
+  by the PR #125 re-key migration** at that action — not authored by
+  Shopify. The 232 `approve_proposal` transitions are the same re-key
+  carry.
+- ⇒ **Cost is authored only by order imports** (and the M6 manual
+  dated-cost flow). No non-order author exists. Shopify / approve /
+  update_field merely relocate an existing cost across a re-key, which
+  a per-item lot ledger handles by construction.
+
+**Q3 — bootstrap: `0/unknown → incoming cost, NO averaging`** (owner
+decision). First lot establishes basis; subsequent lots blend. Items
+with no cost over an interval are surfaced on the exceptions page
+(M6) for review rather than guessed.
+
+**Q1** remains (received date when supplier CSV lacks one) — handled
+by option (a): action-timestamp fallback + `needsReview` + editable
+via `/received-inventory`.
+
+⇒ M2's algorithm is fully specified; M1/M2 unblocked.

--- a/docs/investigations/README.md
+++ b/docs/investigations/README.md
@@ -10,3 +10,4 @@ Records of technical investigations.
 - [Manage Variants modal cannot remove an erroneous subtype](./MANAGE_VARIANTS_CANNOT_REMOVE.md)
 - [Replay performance — Apr 25 backup profile](./REPLAY_PERFORMANCE.md)
 - [SKU Review COST exceptions — supplier-CSV categorization](./COST_EXCEPTIONS.md)
+- [Design: Received Inventory + weighted moving-average cost](./DESIGN_RECEIVED_INVENTORY_AND_MOVING_AVERAGE_COST.md)


### PR DESCRIPTION
## Summary

Concrete design following PR #135's rationale. **Decision: option (a)** — order imports carry a received date; missing/historical dates fall back to the action timestamp and are flagged `needsReview`; a new `/received-inventory` route lets us view and **edit** received dates so past imports can be corrected to the true receipt date; a cost-exceptions page + manual dated-cost flow covers JANs with no received-order coverage.

### Model
- `receivedOrders` registry + per-item `costLots` ledger.
- `cost` is **derived** by a pure fold over lots **sorted by `receivedAt`** (not processing order) — so processing an old order late, or editing a received date, re-derives the past correctly.
- Replay-deterministic: dates come from **action payloads**, never `Date.now()` (reducers are lint-guarded).
- Schema bump **4→5** (new persisted state ⇒ forced re-derive on hydrate; cold replay ~16 s post perf work).
- Perpetual moving-average: prev 0/unknown → overwrite; else blend `(onHandQty·avg + qtyIn·costIn)/(onHandQty+qtyIn)`; shipments reduce on-hand value at avg (COGS); archive resets. Worked checks pinned (user `86.11` example; `4902778028179Black ≈ 262.85`).
- Structured **audit entry to `idToHistory`** on every cost change.

### Milestones (each its own validated PR)
M1 neutralize #134 (reuse its derivation as a lot input) · M2 cost-lot ledger + fold + audit + schema bump · M3 `receivedOrders` registry · M4 `/received-inventory` view+edit · M5 order-import UI received-date capture · M6 cost-exceptions page + `manual_cost_entry`.

### Disposition of open PRs
Keep **#133** (fix A — feeds the ledger); **hold #134** (superseded by M1); **#135** is the rationale.

### Open owner questions (materially shape M2)
(1) received date when supplier CSV lacks one & operator doesn't know it; (2) are Shopify-import/`update_field` cost writes *corrections* or *ignored* once lot data exists; (3) opening-balance bootstrap (recommend: leave uncosted → exceptions page until a manual dated entry); (4) COGS/valuation surfacing (later).

No code change in this PR.

## Test plan
- [x] Date-source reconnaissance on `production-backup-may-16` (no date columns; only session-name codes / `(Order N)`) — motivates option (a)
- [x] Pre-commit (check + full unit suite) and pre-push (live + 26 non-live E2E) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)