### PR TITLE
feat(cost): M2a — cost-lot ledger type + deriveAverageCost fold

### DIFF
--- a/src/lib/inventory.ts
+++ b/src/lib/inventory.ts
@@ -94,6 +94,56 @@ export interface OrderInfo {
     reconciledTimestamp?: number;
   };
 }
+// M2: a received-cost lot. `cost` is never mutated forward — it is
+// DERIVED from this ledger so processing an old order late (or editing
+// a received date) re-derives the past correctly. See
+// docs/investigations/DESIGN_RECEIVED_INVENTORY_AND_MOVING_AVERAGE_COST.md
+export interface CostLot {
+  receivedAt: number;
+  qty: number;
+  unitCost: number;
+  source: string;
+  seq?: number;
+}
+
+/**
+ * Perpetual weighted moving-average over received lots, folded in
+ * receivedAt order (tiebreak: seq, then source). Bootstrap (owner
+ * decision): first lot, or any lot with no established stock/avg, sets
+ * the basis with NO averaging ("0 -> incoming"); subsequent lots blend
+ *   avg = (onHandQty*avg + lot.qty*lot.unitCost)/(onHandQty + lot.qty).
+ * undefined when no usable lots. Sale interleaving (true perpetual
+ * COGS) is a later milestone; receipt-weighted is already strictly
+ * correct vs last-write-wins.
+ */
+export function deriveAverageCost(
+  lots: readonly CostLot[] | undefined,
+): number | undefined {
+  if (!lots || lots.length === 0) return undefined;
+  const ordered = [...lots].sort((a, b) => {
+    if (a.receivedAt !== b.receivedAt) return a.receivedAt - b.receivedAt;
+    const as = a.seq ?? 0;
+    const bs = b.seq ?? 0;
+    if (as !== bs) return as - bs;
+    return String(a.source).localeCompare(String(b.source));
+  });
+  let onHandQty = 0;
+  let avg: number | undefined = undefined;
+  for (const lot of ordered) {
+    const qty = Number(lot.qty) || 0;
+    const unit = Number(lot.unitCost);
+    if (!Number.isFinite(unit)) continue;
+    if (onHandQty <= 0 || avg === undefined || avg === 0) {
+      avg = unit;
+      onHandQty = Math.max(onHandQty, 0) + qty;
+    } else {
+      const denom = onHandQty + qty;
+      avg = denom > 0 ? (onHandQty * avg + qty * unit) / denom : avg;
+      onHandQty = denom;
+    }
+  }
+  return avg;
+}
 export interface InventoryState {
   idToItem: { [key: string]: Item };
   idToHistory: {
@@ -106,6 +156,10 @@ export interface InventoryState {
   salesEvents: { [key: string]: OrderInfo };
   orderIdToOrder: { [key: string]: OrderInfo };
   shopifyUrlToDriveUrl: { [key: string]: string }; // [shopifyUrl] -> driveUrl
+  // M2: per-item received-cost lot ledger. cost is DERIVED from this
+  // via deriveAverageCost (sorted by receivedAt). See
+  // docs/investigations/DESIGN_RECEIVED_INVENTORY_AND_MOVING_AVERAGE_COST.md
+  costLots?: { [key: string]: CostLot[] };
   hiddenExceptions?: { [key: string]: boolean };
   shopifyExceptions?: { [key: string]: string[] };
   etsyExceptions?: { [key: string]: string[] };
@@ -954,6 +1008,7 @@ export const initialState: InventoryState = {
   hiddenInventoryState: {},
   salesEvents: {},
   shopifyUrlToDriveUrl: {},
+  costLots: {},
   shopifyExceptions: {},
   etsyExceptions: {},
   initialized: false,
@@ -2410,6 +2465,7 @@ export const inventory = createReducer(initialState, (r) => {
       archivedInventoryState: {},
       hiddenInventoryState: {},
       shopifyUrlToDriveUrl: {},
+      costLots: {},
       initialized: state.initialized,
     });
     const timestamp = (action as any).timestamp;

--- a/tests/unit/derive-average-cost.test.ts
+++ b/tests/unit/derive-average-cost.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { deriveAverageCost, type CostLot } from "$lib/inventory";
+
+// M2a — pure receipt-weighted moving-average fold.
+// See docs/investigations/DESIGN_RECEIVED_INVENTORY_AND_MOVING_AVERAGE_COST.md
+//
+// SCOPE: this is receipt-weighted (lots only). Sale-interleaved
+// perpetual COGS (which yields the owner's 86.11 example) is a
+// SEPARATE pending milestone — see the explicit test below.
+
+const lot = (
+  receivedAt: number,
+  qty: number,
+  unitCost: number,
+  source = "o",
+  seq?: number,
+): CostLot => ({ receivedAt, qty, unitCost, source, seq });
+
+describe("deriveAverageCost (receipt-weighted fold)", () => {
+  it("returns undefined for no lots", () => {
+    expect(deriveAverageCost(undefined)).toBeUndefined();
+    expect(deriveAverageCost([])).toBeUndefined();
+  });
+
+  it("bootstrap: a single lot establishes basis with no averaging", () => {
+    expect(deriveAverageCost([lot(1, 10, 282.7)])).toBe(282.7);
+  });
+
+  it("blends subsequent lots qty-weighted (4902778028179Black)", () => {
+    // Order1 ¥282.70 ×10, Order5 ¥243 ×10  ->  (10·282.7+10·243)/20
+    expect(
+      deriveAverageCost([lot(100, 10, 282.7), lot(200, 10, 243)]),
+    ).toBeCloseTo(262.85, 6);
+  });
+
+  it("matches hand-computed values for the other flagged JANs", () => {
+    // 4977564637699 Green: ¥385×20 (Ord3) + ¥201×40 (Ord5) -> 262.33…
+    expect(deriveAverageCost([lot(1, 20, 385), lot(2, 40, 201)])).toBeCloseTo(
+      15740 / 60,
+      6,
+    );
+    // 4952270287321 Cat in Mug: ¥194×5 + ¥97×20 -> 116.4
+    expect(deriveAverageCost([lot(1, 5, 194), lot(2, 20, 97)])).toBeCloseTo(
+      116.4,
+      6,
+    );
+  });
+
+  it("is input-order independent but receivedAt-order dependent (temporal guarantee)", () => {
+    const a = lot(100, 10, 282.7);
+    const b = lot(200, 10, 243);
+    // Same lots, array order shuffled -> identical (fold sorts by receivedAt)
+    expect(deriveAverageCost([a, b])).toBe(deriveAverageCost([b, a]));
+    // A *late-processed but earlier-received* lot changes the result to
+    // the date-ordered fold (this is what makes "process last year's
+    // order today, affect the past" correct).
+    const withEarlyLot = deriveAverageCost([
+      lot(200, 10, 243),
+      lot(50, 5, 100), // received BEFORE the 282.7 lot, processed last
+      lot(100, 10, 282.7),
+    ]);
+    // date order: (5@100) -> est 100; +(10@282.7) -> (5·100+10·282.7)/15
+    // -> +(10@243) -> blend again
+    let q = 5,
+      avg = 100;
+    avg = (q * avg + 10 * 282.7) / (q + 10);
+    q += 10;
+    avg = (q * avg + 10 * 243) / (q + 10);
+    q += 10;
+    expect(withEarlyLot).toBeCloseTo(avg, 6);
+  });
+
+  it("deterministic tiebreak when receivedAt collides (seq, then source)", () => {
+    const r1 = deriveAverageCost([
+      lot(100, 10, 300, "B", 2),
+      lot(100, 10, 100, "A", 1),
+    ]);
+    const r2 = deriveAverageCost([
+      lot(100, 10, 100, "A", 1),
+      lot(100, 10, 300, "B", 2),
+    ]);
+    expect(r1).toBe(r2); // order-independent given seq
+    // seq 1 (cost 100) establishes basis, then seq 2 blends:
+    expect(r1).toBeCloseTo((10 * 100 + 10 * 300) / 20, 6);
+  });
+
+  it("ignores non-finite unit costs", () => {
+    expect(deriveAverageCost([lot(1, 10, Number.NaN), lot(2, 5, 50)])).toBe(50);
+  });
+
+  it("DOCUMENTED LIMITATION: receipt-weighted ≠ sale-interleaved perpetual", () => {
+    // Owner example: buy 10@100, SELL 2, buy 10@75.
+    // True perpetual (sale-aware) = (8·100 + 10·75)/18 = 86.11…
+    // M2a receipt-weighted (no sale modelling) = (10·100+10·75)/20 = 87.5.
+    // The sale-aware milestone is pending owner sign-off; this test
+    // pins the CURRENT (receipt-weighted) behaviour so the gap is
+    // explicit, not silently wrong.
+    expect(deriveAverageCost([lot(1, 10, 100), lot(2, 10, 75)])).toBe(87.5);
+  });
+});


### PR DESCRIPTION
## Summary

First implementation step of `DESIGN_RECEIVED_INVENTORY_AND_MOVING_AVERAGE_COST.md` (PR #136). Both design blockers cleared: **Q2 proven specious** (no Shopify/`update_field` cost authorship — 0 `update_field` cost actions; the one shopify cost "transition" is a PR #125 re-key carry of an order-import cost), **Q3 settled** by owner (`0 → incoming, no averaging`; uncosted-interval exceptions page).

**Pure-additive foundation, NO wiring:**
- `CostLot` type + optional `inventory.costLots` state (initialState + archive-clone reset).
- `deriveAverageCost()` — perpetual weighted moving-average folded in **`receivedAt` order** (deterministic tiebreak `seq`→`source`); bootstrap: first/unestablished lot sets basis with no averaging, subsequent lots blend `(onHandQty·avg + lot.qty·lot.unitCost)/(onHandQty+lot.qty)`.
- 8 unit tests: bootstrap, blend, hand-computed values for the flagged JANs (`4902778028179Black` 262.85, Green 262.33, Cat in Mug 116.4), **input-order independence + receivedAt-order dependence** (the temporal "process last year's order today → affect the past" guarantee), collision tiebreak, NaN guard.

## ⚠️ Documented scope limitation (decision pending)

The fold is **receipt-weighted**. The owner's `buy 10@100 / sell 2 / buy 10@75` example wants **86.11** (sale-aware perpetual); receipt-weighted yields **87.5**. A `DOCUMENTED LIMITATION` test pins this gap explicitly (not silently wrong). Whether M2 targets **(i) receipt-weighted now** [recommended; dominant fix, no sale-date dependency] or **(ii) full sale-interleaved perpetual** [matches 86.11, much bigger] is awaiting owner decision; M2b+ proceed accordingly.

## Validation
- Nothing reads `costLots` yet ⇒ **no schema bump**; full may-16 inventory dump **byte-identical** to main (zero derived-state change).
- `bun run check` clean; pre-commit (full unit suite) + pre-push (live + 26 non-live E2E) green.

Next: M2b wire order-import → append lots + derive cost; M2c migrate lots across re-key paths; M2d schema bump + hand-checked before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)