### PR TITLE
Inventory cost: derived cost-lot ledger (M1–M3a)

### DIFF
--- a/src/lib/cost-engine.ts
+++ b/src/lib/cost-engine.ts
@@ -1,0 +1,114 @@
+// Inventory cost & valuation engine.
+// See docs/investigations/DESIGN_INVENTORY_COST_AND_VALUATION.md
+//
+// Pure, deterministic. Given an item's date-sorted ledger of receipts and
+// sales, walking it (optionally truncated to an as-of date) yields the
+// on-hand quantity and the perpetual weighted-average cost in JPY and EUR.
+// "Cost now" is a walk with asOf = +Infinity.
+
+// Placeholder used when a stock order's true receipt date is unknown.
+// The engine treats it as an ordinary date; only the exceptions surface
+// recognises it, so computation never branches on "problem exists".
+export const UNKNOWN_RECEIPT_DATE = Date.UTC(2026, 0, 1); // 2026-01-01
+
+export type ReceiptEntry = {
+  kind: "receipt";
+  at: number; // epoch ms; always a real date (UNKNOWN_RECEIPT_DATE if not known)
+  seq: number; // deterministic tiebreak within equal `at`
+  qty: number;
+  unitCostJpy: number; // always a number (0 = unknown, surfaced elsewhere)
+  unitCostEur: number; // always a number (0 = unknown, surfaced elsewhere)
+};
+
+export type SaleEntry = {
+  kind: "sale";
+  at: number;
+  seq: number;
+  qty: number;
+};
+
+export type LedgerEntry = ReceiptEntry | SaleEntry;
+
+export interface CostState {
+  onHand: number;
+  avgJpy: number;
+  avgEur: number;
+}
+
+export interface Valuation extends CostState {
+  valueJpy: number;
+  valueEur: number;
+}
+
+// Stable order: ascending by date, then by seq. Input is not mutated.
+function sortLedger(entries: readonly LedgerEntry[]): LedgerEntry[] {
+  return entries
+    .map((e, i) => ({ e, i }))
+    .sort((a, b) => {
+      if (a.e.at !== b.e.at) return a.e.at - b.e.at;
+      if (a.e.seq !== b.e.seq) return a.e.seq - b.e.seq;
+      return a.i - b.i; // preserve insertion order on full tie
+    })
+    .map((x) => x.e);
+}
+
+/**
+ * Walk the ledger up to and including `asOf` (default: all entries).
+ * Perpetual weighted-average: a receipt blends into the running average;
+ * a sale reduces on-hand and leaves the average unchanged.
+ */
+export function walkLedger(
+  entries: readonly LedgerEntry[],
+  asOf: number = Number.POSITIVE_INFINITY,
+): CostState {
+  let onHand = 0;
+  let avgJpy = 0;
+  let avgEur = 0;
+
+  for (const e of sortLedger(entries)) {
+    if (e.at > asOf) break;
+    if (e.kind === "receipt") {
+      const next = onHand + e.qty;
+      if (next <= 0) {
+        // Degenerate (e.g. zero/negative qty): nothing to blend.
+        onHand = next > 0 ? next : 0;
+        continue;
+      }
+      avgJpy = (onHand * avgJpy + e.qty * e.unitCostJpy) / next;
+      avgEur = (onHand * avgEur + e.qty * e.unitCostEur) / next;
+      onHand = next;
+    } else {
+      onHand = Math.max(0, onHand - e.qty);
+    }
+  }
+
+  return { onHand, avgJpy, avgEur };
+}
+
+/** Value of the item as of `asOf` = on-hand × weighted-average cost. */
+export function valueAt(
+  entries: readonly LedgerEntry[],
+  asOf: number = Number.POSITIVE_INFINITY,
+): Valuation {
+  const s = walkLedger(entries, asOf);
+  return {
+    ...s,
+    valueJpy: s.onHand * s.avgJpy,
+    valueEur: s.onHand * s.avgEur,
+  };
+}
+
+/** Total inventory value across many items as of `asOf`. */
+export function totalValuation(
+  ledgers: Iterable<readonly LedgerEntry[]>,
+  asOf: number = Number.POSITIVE_INFINITY,
+): { valueJpy: number; valueEur: number } {
+  let valueJpy = 0;
+  let valueEur = 0;
+  for (const l of ledgers) {
+    const v = valueAt(l, asOf);
+    valueJpy += v.valueJpy;
+    valueEur += v.valueEur;
+  }
+  return { valueJpy, valueEur };
+}

--- a/src/lib/cost-engine.ts
+++ b/src/lib/cost-engine.ts
@@ -11,19 +11,6 @@
 // recognises it, so computation never branches on "problem exists".
 export const UNKNOWN_RECEIPT_DATE = Date.UTC(2026, 0, 1); // 2026-01-01
 
-/**
- * Parse an item `creationDate` ("Mon D, YYYY (n)" or "Mon D, YYYY") to
- * epoch ms. The trailing " (n)" batch marker is ignored. Unparseable
- * input falls back to UNKNOWN_RECEIPT_DATE so callers never get NaN/null.
- */
-export function parseReceiptDate(creationDate: unknown): number {
-  const head = String(creationDate ?? "")
-    .split(" (")[0]
-    .trim();
-  const t = Date.parse(head);
-  return Number.isFinite(t) ? t : UNKNOWN_RECEIPT_DATE;
-}
-
 export type ReceiptEntry = {
   kind: "receipt";
   at: number; // epoch ms; always a real date (UNKNOWN_RECEIPT_DATE if not known)

--- a/src/lib/cost-engine.ts
+++ b/src/lib/cost-engine.ts
@@ -11,6 +11,19 @@
 // recognises it, so computation never branches on "problem exists".
 export const UNKNOWN_RECEIPT_DATE = Date.UTC(2026, 0, 1); // 2026-01-01
 
+/**
+ * Parse an item `creationDate` ("Mon D, YYYY (n)" or "Mon D, YYYY") to
+ * epoch ms. The trailing " (n)" batch marker is ignored. Unparseable
+ * input falls back to UNKNOWN_RECEIPT_DATE so callers never get NaN/null.
+ */
+export function parseReceiptDate(creationDate: unknown): number {
+  const head = String(creationDate ?? "")
+    .split(" (")[0]
+    .trim();
+  const t = Date.parse(head);
+  return Number.isFinite(t) ? t : UNKNOWN_RECEIPT_DATE;
+}
+
 export type ReceiptEntry = {
   kind: "receipt";
   at: number; // epoch ms; always a real date (UNKNOWN_RECEIPT_DATE if not known)

--- a/src/lib/inventory.ts
+++ b/src/lib/inventory.ts
@@ -11,6 +11,12 @@ import {
   type FirestoreTimestampLike,
   toTimestampMs,
 } from "./timestamped-action";
+import {
+  type LedgerEntry,
+  walkLedger,
+  parseReceiptDate,
+  UNKNOWN_RECEIPT_DATE,
+} from "./cost-engine";
 
 // TODO hceck item history for 4542804115635Silver
 export interface Item {
@@ -109,7 +115,19 @@ export interface InventoryState {
   hiddenExceptions?: { [key: string]: boolean };
   shopifyExceptions?: { [key: string]: string[] };
   etsyExceptions?: { [key: string]: string[] };
+  // Per-item date-sorted receipt/sale ledger; `cost` is derived from it.
+  // See docs/investigations/DESIGN_INVENTORY_COST_AND_VALUATION.md
+  costLedger?: { [key: string]: LedgerEntry[] };
+  // Per stock-order receipt date + JPY/EUR totals (owner-supplied).
+  stockOrderRegistry?: { [orderId: string]: StockOrderMeta };
   initialized: boolean;
+}
+
+export interface StockOrderMeta {
+  supplier?: string;
+  receivedAt?: number; // epoch ms; absent -> UNKNOWN_RECEIPT_DATE
+  totalOrderJpy?: number;
+  totalOrderEur?: number;
 }
 
 export type InventoryEntityId = string;
@@ -248,11 +266,27 @@ export interface BulkImportItem {
   type: "new" | "update";
   id: InventoryItemKey | string; // janCode or itemKey
   item: Item; // The full item object or partial update
+  // Present when this row originates from a stock-order import. Marks the
+  // qty delta as a genuine receipt (vs. archive-restore / manual / live)
+  // and carries the per-unit cost + receipt date for the ledger.
+  stockOrder?: {
+    orderId: string;
+    unitCostJpy: number;
+    unitCostEur: number;
+    receivedAt: number;
+  };
 }
 
 export const bulk_import_items = createAction<{
   items: Array<BulkImportItem>;
 }>("bulk_import_items");
+
+// Owner-supplied receipt date / paid-exchange totals for a stock order.
+// Replays like any other action; the ledger reads it on materialisation.
+export const set_stock_order_meta = createAction<{
+  orderId: string;
+  meta: StockOrderMeta;
+}>("set_stock_order_meta");
 
 export const shopify_order_created = createAction<{
   raw: any;
@@ -684,8 +718,55 @@ function migrateBareJanRowToCanonical(
     ].sort((a, b) => (a.val || 0) - (b.val || 0));
   }
 
+  migrateCostLedger(state, oldKey, canonicalId);
+
   delete state.idToItem[oldKey];
   delete state.idToHistory[oldKey];
+}
+
+// Carry the cost ledger with the item across a key change/merge. Entries
+// from the old key are appended after the destination's and re-seq'd so
+// the deterministic (at, seq) order is preserved; the destination cost is
+// re-derived. See docs/investigations/DESIGN_INVENTORY_COST_AND_VALUATION.md
+function migrateCostLedger(
+  state: InventoryState,
+  oldKey: string,
+  newKey: string,
+) {
+  if (!state.costLedger || !state.costLedger[oldKey]) return;
+  if (!state.costLedger[newKey]) state.costLedger[newKey] = [];
+  const merged = [...state.costLedger[newKey], ...state.costLedger[oldKey]];
+  merged.forEach((e, i) => (e.seq = i));
+  state.costLedger[newKey] = merged;
+  delete state.costLedger[oldKey];
+  rederiveCostFromLedger(state, newKey);
+}
+
+// Copy (don't move) a ledger to a new key — for splits where the source
+// row survives. Entries are deep-cloned so later mutation is independent.
+function copyCostLedger(
+  state: InventoryState,
+  sourceKey: string,
+  newKey: string,
+) {
+  if (!state.costLedger || !state.costLedger[sourceKey]) return;
+  state.costLedger[newKey] = state.costLedger[sourceKey].map((e, i) => ({
+    ...e,
+    seq: i,
+  }));
+  rederiveCostFromLedger(state, newKey);
+}
+
+function rederiveCostFromLedger(state: InventoryState, key: string) {
+  const ledger = state.costLedger?.[key];
+  const item = state.idToItem[key];
+  if (!ledger || !item) return;
+  const hasPriced = ledger.some(
+    (e) => e.kind === "receipt" && e.unitCostJpy > 0,
+  );
+  if (ledger.length >= 2 || hasPriced) {
+    item.cost = walkLedger(ledger).avgJpy;
+  }
 }
 
 // Helper to apply update logic
@@ -696,6 +777,7 @@ function applyInventoryUpdate(
   timestamp: any,
   actionType = "update_item",
   actionDocId?: string,
+  stockOrder?: BulkImportItem["stockOrder"],
 ) {
   if (!id) {
     console.error(
@@ -924,6 +1006,67 @@ function applyInventoryUpdate(
   // Always try to bind, it handles its own idempotency
   bindNewInventoryEntity(state, id, val, actionType, actionDocId);
 
+  // --- Cost-lot ledger materialisation -------------------------------
+  // See docs/investigations/DESIGN_INVENTORY_COST_AND_VALUATION.md
+  // `cost` is derived from this ledger. Single-receipt items derive the
+  // exact same value as the old last-write (walk of one priced lot ==
+  // that lot's cost); only genuine stock-order re-orders add a second
+  // lot and therefore blend. Never-priced items keep cost untouched.
+  if (!state.costLedger) state.costLedger = {};
+  if (!state.costLedger[id]) state.costLedger[id] = [];
+  const ledger = state.costLedger[id];
+  const deltaQty = Number(item.qty);
+  let ledgerChanged = false;
+
+  if (isNewItem) {
+    ledger.push({
+      kind: "receipt",
+      at: parseReceiptDate(state.idToItem[id].creationDate),
+      seq: ledger.length,
+      qty: Number.isFinite(deltaQty) ? deltaQty : 0,
+      unitCostJpy: Number(item.cost) > 0 ? Number(item.cost) : 0,
+      unitCostEur: 0,
+    });
+    ledgerChanged = true;
+  } else if (stockOrder) {
+    if (Number.isFinite(deltaQty) && deltaQty > 0) {
+      // Genuine re-order: a new dated receipt at the re-order price.
+      ledger.push({
+        kind: "receipt",
+        at: stockOrder.receivedAt || UNKNOWN_RECEIPT_DATE,
+        seq: ledger.length,
+        qty: deltaQty,
+        unitCostJpy: stockOrder.unitCostJpy,
+        unitCostEur: stockOrder.unitCostEur,
+      });
+      ledgerChanged = true;
+    } else {
+      // Original order (qty 0): attach landed cost to unpriced receipts.
+      for (const e of ledger) {
+        if (e.kind === "receipt" && !(e.unitCostJpy > 0)) {
+          e.unitCostJpy = stockOrder.unitCostJpy;
+          e.unitCostEur = stockOrder.unitCostEur;
+          ledgerChanged = true;
+        }
+      }
+    }
+  }
+
+  if (ledgerChanged) {
+    const hasPriced = ledger.some(
+      (e) => e.kind === "receipt" && e.unitCostJpy > 0,
+    );
+    if (ledger.length >= 2 || hasPriced) {
+      const derived = walkLedger(ledger).avgJpy;
+      state.idToItem[id].cost = derived;
+      historyEntries.push({
+        date: globalDate,
+        desc: `Cost derived from ${ledger.length} lot(s): ${formatYen(derived)}`,
+        val,
+      });
+    }
+  }
+
   // 3. Push History
   // Final check before push
   if (!state.idToHistory[id]) {
@@ -956,6 +1099,8 @@ export const initialState: InventoryState = {
   shopifyUrlToDriveUrl: {},
   shopifyExceptions: {},
   etsyExceptions: {},
+  costLedger: {},
+  stockOrderRegistry: {},
   initialized: false,
 };
 
@@ -1707,6 +1852,14 @@ export const inventory = createReducer(initialState, (r) => {
       delete state.hiddenExceptions[action.payload.itemKey];
     }
   });
+  r.addCase(set_stock_order_meta, (state, action) => {
+    if (!state.stockOrderRegistry) state.stockOrderRegistry = {};
+    const { orderId, meta } = action.payload;
+    state.stockOrderRegistry[orderId] = {
+      ...state.stockOrderRegistry[orderId],
+      ...meta,
+    };
+  });
   r.addCase(update_item, (state, action) => {
     applyInventoryUpdate(
       state,
@@ -1774,6 +1927,7 @@ export const inventory = createReducer(initialState, (r) => {
           getTimestampMs((action as any).timestamp),
           action.type,
         );
+        migrateCostLedger(state, itemKey, mergeItemKey);
 
         // Merge history
         const oldHistory = state.idToHistory[itemKey] || [];
@@ -2200,6 +2354,7 @@ export const inventory = createReducer(initialState, (r) => {
         getTimestampMs((action as any).timestamp),
         action.type,
       );
+      migrateCostLedger(state, itemKey, mergeItemKey);
 
       // Merge history: Copy old history to new key
       const oldHistory = state.idToHistory[itemKey] || [];
@@ -2318,6 +2473,7 @@ export const inventory = createReducer(initialState, (r) => {
     // Rewrite order line items and consolidate duplicates.
     rewriteOrderItemKeyReferences(state, oldKey, newKey);
     renameInventoryEntityKey(state, oldKey, newKey, val, action.type);
+    migrateCostLedger(state, oldKey, newKey);
 
     if (!state.idToHistory[newKey]) {
       state.idToHistory[newKey] = [];
@@ -2579,6 +2735,9 @@ export const inventory = createReducer(initialState, (r) => {
         };
       }
 
+      // New item inherits the source's cost basis (same unit cost).
+      copyCostLedger(state, sourceId, split.newId);
+
       // History for new item
       if (!state.idToHistory[split.newId]) state.idToHistory[split.newId] = [];
       state.idToHistory[split.newId].push({
@@ -2599,6 +2758,7 @@ export const inventory = createReducer(initialState, (r) => {
     if (sourceItem.qty <= 0) {
       closeInventoryEntityKey(state, sourceId, val, action.type);
       delete state.idToItem[sourceId];
+      if (state.costLedger) delete state.costLedger[sourceId];
     }
   });
 
@@ -2614,6 +2774,7 @@ export const inventory = createReducer(initialState, (r) => {
         timestamp,
         action.type,
         (action as any).id,
+        update.stockOrder,
       );
     });
   });

--- a/src/lib/inventory.ts
+++ b/src/lib/inventory.ts
@@ -10,11 +10,11 @@ export type { InventoryItemKey };
 import {
   type FirestoreTimestampLike,
   toTimestampMs,
+  deriveCreationTimestampMs,
 } from "./timestamped-action";
 import {
   type LedgerEntry,
   walkLedger,
-  parseReceiptDate,
   UNKNOWN_RECEIPT_DATE,
 } from "./cost-engine";
 
@@ -1040,17 +1040,22 @@ function applyInventoryUpdate(
   const deltaQty = Number(item.qty);
   let ledgerChanged = false;
 
-  if (isNewItem) {
+  // Pending writes (atMs <= 0, e.g. an optimistic local write before the
+  // server timestamp resolves) are guarded here exactly like entity
+  // binding: defer ledger materialisation until the confirming write
+  // carries a real timestamp. deriveCreationTimestampMs stays strict —
+  // it is only reached on a resolved (val > 0) timestamp.
+  if (val > 0 && isNewItem) {
     ledger.push({
       kind: "receipt",
-      at: parseReceiptDate(state.idToItem[id].creationDate),
+      at: deriveCreationTimestampMs(timestamp),
       seq: ledger.length,
       qty: Number.isFinite(deltaQty) ? deltaQty : 0,
       unitCostJpy: Number(item.cost) > 0 ? Number(item.cost) : 0,
       unitCostEur: 0,
     });
     ledgerChanged = true;
-  } else if (stockOrder) {
+  } else if (val > 0 && stockOrder) {
     if (Number.isFinite(deltaQty) && deltaQty > 0) {
       // Genuine re-order: a new dated receipt at the re-order price.
       ledger.push({
@@ -1993,12 +1998,11 @@ export const inventory = createReducer(initialState, (r) => {
       let val = 0;
       let creationDate = "Invalid Date";
 
+      // Pending-tolerant (null / {seconds:0} are valid pending writes
+      // here, not errors): resolve via the canonical converter and only
+      // format a date when it resolves to a real (> 0) time.
       if (timestamp) {
-        if (timestamp.seconds) {
-          val = new Date(timestamp.seconds * 1000).getTime();
-        } else if (typeof timestamp === "number") {
-          val = timestamp;
-        }
+        val = toTimestampMs(timestamp as FirestoreTimestampLike) ?? 0;
 
         if (val > 0) {
           creationDate = new Date(val).toLocaleString("en", {

--- a/src/lib/inventory.ts
+++ b/src/lib/inventory.ts
@@ -757,6 +757,28 @@ function copyCostLedger(
   rederiveCostFromLedger(state, newKey);
 }
 
+// Append a dated sale (outflow) to the ledger so the perpetual walk
+// reduces on-hand at the right point in time. `qty` may be negative
+// (a refund/cancel/reset restores on-hand). No-op if the item has no
+// ledger (nothing was ever received -> sale is irrelevant to cost).
+function recordSale(
+  state: InventoryState,
+  key: string,
+  qty: number,
+  atMs: number,
+) {
+  if (!qty || !Number.isFinite(qty)) return;
+  if (!state.costLedger || !state.costLedger[key]) return;
+  const ledger = state.costLedger[key];
+  ledger.push({
+    kind: "sale",
+    at: Number.isFinite(atMs) && atMs > 0 ? atMs : UNKNOWN_RECEIPT_DATE,
+    seq: ledger.length,
+    qty,
+  });
+  rederiveCostFromLedger(state, key);
+}
+
 function rederiveCostFromLedger(state: InventoryState, key: string) {
   const ledger = state.costLedger?.[key];
   const item = state.idToItem[key];
@@ -1368,6 +1390,7 @@ export const inventory = createReducer(initialState, (r) => {
       if (state.idToItem[effectiveKey]) {
         if (!isReconciledLater && delta > 0) {
           state.idToItem[effectiveKey].shipped += delta;
+          recordSale(state, effectiveKey, delta, effectiveAtMs);
         }
 
         const historyVal = actionTimestamp;
@@ -1596,6 +1619,7 @@ export const inventory = createReducer(initialState, (r) => {
       if (diff !== 0) {
         if (state.idToItem[canonicalKey]) {
           state.idToItem[canonicalKey].shipped += diff;
+          recordSale(state, canonicalKey, diff, effectiveAtMs);
           const historyVal = actionTimestamp;
           if (!state.idToHistory[canonicalKey])
             state.idToHistory[canonicalKey] = [];
@@ -1618,6 +1642,7 @@ export const inventory = createReducer(initialState, (r) => {
       const canonicalKey = key as InventoryItemKey;
       if (qty !== 0 && state.idToItem[canonicalKey]) {
         state.idToItem[canonicalKey].shipped -= qty;
+        recordSale(state, canonicalKey, -qty, effectiveAtMs);
         const historyVal = actionTimestamp;
         if (!state.idToHistory[canonicalKey])
           state.idToHistory[canonicalKey] = [];
@@ -1794,6 +1819,7 @@ export const inventory = createReducer(initialState, (r) => {
     for (const [canonicalKey, diff] of Object.entries(netDiffMap)) {
       if (diff !== 0 && state.idToItem[canonicalKey] !== undefined) {
         state.idToItem[canonicalKey].shipped += diff;
+        recordSale(state, canonicalKey, diff, effectiveAtMs);
         if (!state.idToHistory[canonicalKey])
           state.idToHistory[canonicalKey] = [];
         state.idToHistory[canonicalKey].push({
@@ -2655,9 +2681,14 @@ export const inventory = createReducer(initialState, (r) => {
         });
       }
     }
+    const date = action.payload.date;
+    const saleAtMs =
+      date instanceof Date ? date.getTime() : getTimestampMs(date);
+    for (const it of items) {
+      recordSale(state, it.itemKey, it.qty, saleAtMs);
+    }
     const email = "dobutsustationery@gmail.com";
     const product = archiveName;
-    const date = action.payload.date;
     state.salesEvents[archiveName] = {
       id: orderID,
       items,

--- a/src/lib/order-import-slice.ts
+++ b/src/lib/order-import-slice.ts
@@ -1,5 +1,6 @@
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 import Papa from "papaparse";
+import { parseStockOrderUnitCostJpy } from "./stock-order-cost";
 
 export interface ImportItem {
   janCode: string;
@@ -167,10 +168,17 @@ const mapImportItem = (row: any): ImportItem => {
     qty,
     carton: row["carton number"] || row["carton"] || "",
     hsCode: findHSCode(row),
-    // Map CSV 'unit price (yen)' (supplier cost) to 'cost'. Strict match required.
-    cost: row["unit price (yen)"]
-      ? parseFloat(row["unit price (yen)"].replace(/[^0-9.]/g, ""))
-      : undefined,
+    // Per-unit JPY supplier cost. M1 rule (design §6.2): explicit
+    // unit-price column if finite, else Total Wholesale Amount YEN ÷
+    // Order Q'ty PCS (Q'ty UNIT disregarded). 0 -> unknown -> undefined.
+    cost: (() => {
+      const keys = Object.keys(row);
+      const v = parseStockOrderUnitCostJpy(
+        keys,
+        keys.map((k) => row[k]),
+      );
+      return v > 0 ? v : undefined;
+    })(),
     price: undefined,
     weight,
     countryOfOrigin: countryOfOrigin || undefined,

--- a/src/lib/root-reducer.ts
+++ b/src/lib/root-reducer.ts
@@ -12,6 +12,7 @@ import {
   split_inventory_item,
   fix_jancode,
 } from "./inventory";
+import { UNKNOWN_RECEIPT_DATE } from "./cost-engine";
 import { names } from "./names";
 import { photos, rename_jan_group } from "./photos-slice";
 import {
@@ -1090,11 +1091,35 @@ export const rootReducer = (
       filter,
     );
 
-    const bulkUpdates: BulkImportItem[] = updates.map((u) => ({
-      type: u.type,
-      id: u.id,
-      item: u.type === "new" ? mapOrderToInventory(u.item) : u.item,
-    }));
+    const orderId =
+      nextState.orderImport.activeFile?.id ||
+      nextState.orderImport.activeFile?.name ||
+      "unknown-stock-order";
+    const meta = nextState.inventory.stockOrderRegistry?.[orderId];
+    const receivedAt =
+      meta?.receivedAt && Number.isFinite(meta.receivedAt)
+        ? meta.receivedAt
+        : UNKNOWN_RECEIPT_DATE;
+    const fx =
+      meta?.totalOrderJpy && meta?.totalOrderEur && meta.totalOrderJpy > 0
+        ? meta.totalOrderEur / meta.totalOrderJpy
+        : 0;
+
+    const bulkUpdates: BulkImportItem[] = updates.map((u) => {
+      const item = u.type === "new" ? mapOrderToInventory(u.item) : u.item;
+      const unitCostJpy = Number(item.cost) > 0 ? Number(item.cost) : 0;
+      return {
+        type: u.type,
+        id: u.id,
+        item,
+        stockOrder: {
+          orderId,
+          unitCostJpy,
+          unitCostEur: fx > 0 ? unitCostJpy * fx : 0,
+          receivedAt,
+        },
+      };
+    });
 
     if (bulkUpdates.length > 0) {
       const internalAction = inheritTimestamp({

--- a/src/lib/schema-version.ts
+++ b/src/lib/schema-version.ts
@@ -3,4 +3,9 @@
  * Increment this number to invalidate all hydrated state and force a full replay of broadcast actions.
  * Use this whenever the shape of the state changes in a non-backward-compatible way.
  */
-export const CURRENT_SCHEMA_VERSION = 4;
+// 5: `cost` is now DERIVED from a per-item receipt/sale costLedger
+//    (perpetual weighted-average) instead of last-write. Hydrated v4
+//    snapshots carry stale last-write cost and no costLedger, so they
+//    must be discarded and re-derived via full replay. See
+//    docs/investigations/DESIGN_INVENTORY_COST_AND_VALUATION.md
+export const CURRENT_SCHEMA_VERSION = 5;

--- a/src/lib/stock-order-cost.ts
+++ b/src/lib/stock-order-cost.ts
@@ -1,0 +1,84 @@
+// Per-unit JPY cost of a stock-order CSV line.
+// See docs/investigations/DESIGN_INVENTORY_COST_AND_VALUATION.md §6.2
+//
+// Rule:
+//   - if an explicit finite per-unit price column is present, use it;
+//   - else  Total Wholesale Amount YEN ÷ Order Q'ty PCS.
+//   - Order Q'ty UNIT (pieces per pack) is DISREGARDED — PCS is the
+//     total piece count and is a multiple of UNIT.
+// Pure and header-driven; headers differ per supplier so matching is by
+// normalised header text. Returns 0 when not computable (the "needs
+// cost" sentinel — surfaced by the exceptions code, never here).
+
+export const STOCK_ORDER_UNIT_COST_UNKNOWN = 0;
+
+/** lowercase, drop every non-alphanumeric char (handles newlines, ¥, '). */
+export function normalizeHeader(h: string): string {
+  return String(h)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "");
+}
+
+/** Parse a possibly formatted number: " 4,700 " -> 4700, "¥1,234.5" -> 1234.5. */
+export function parseAmount(v: unknown): number {
+  if (typeof v === "number") return Number.isFinite(v) ? v : NaN;
+  const s = String(v ?? "").replace(/[^0-9.\-]/g, "");
+  if (s === "" || s === "-" || s === "." || s === "-.") return NaN;
+  return Number.parseFloat(s);
+}
+
+function buildIndex(headers: readonly string[]): Map<string, number> {
+  const idx = new Map<string, number>();
+  headers.forEach((h, i) => {
+    const n = normalizeHeader(h);
+    if (n && !idx.has(n)) idx.set(n, i);
+  });
+  return idx;
+}
+
+function find(
+  idx: Map<string, number>,
+  pred: (normalizedHeader: string) => boolean,
+): number {
+  for (const [k, i] of idx) if (pred(k)) return i;
+  return -1;
+}
+
+/**
+ * Per-unit JPY cost for one stock-order row.
+ * @param headers the CSV header row (first row of rawRows)
+ * @param row     the data row, cell-aligned with headers
+ */
+export function parseStockOrderUnitCostJpy(
+  headers: readonly string[],
+  row: readonly unknown[],
+): number {
+  const idx = buildIndex(headers);
+
+  // 1. Explicit per-unit price column (e.g. "UNIT PRICE (YEN)").
+  //    Must not collide with "Q'ty per UNIT" / "ORDER Q'ty UNIT".
+  const priceCol = find(
+    idx,
+    (h) => h.includes("unitprice") && h.includes("yen"),
+  );
+  if (priceCol >= 0) {
+    const p = parseAmount(row[priceCol]);
+    if (Number.isFinite(p) && p > 0) return p;
+  }
+
+  // 2. Total Wholesale Amount YEN ÷ Order Q'ty PCS.
+  const totalCol = find(
+    idx,
+    (h) => h.includes("totalwholesale") && h.includes("yen"),
+  );
+  const pcsCol = find(idx, (h) => h.includes("qty") && h.includes("pcs"));
+  if (totalCol >= 0 && pcsCol >= 0) {
+    const total = parseAmount(row[totalCol]);
+    const pcs = parseAmount(row[pcsCol]);
+    if (Number.isFinite(total) && Number.isFinite(pcs) && pcs > 0) {
+      return total / pcs;
+    }
+  }
+
+  return STOCK_ORDER_UNIT_COST_UNKNOWN;
+}

--- a/src/lib/timestamped-action.ts
+++ b/src/lib/timestamped-action.ts
@@ -59,6 +59,26 @@ export const toTimestampMs = (ts: FirestoreTimestampLike): number | null => {
   return null;
 };
 
+/**
+ * Derive an entity's creation/receipt timestamp (epoch ms) from an
+ * action timestamp. This is the single source of truth for "when was
+ * this created" — never parse a formatted `creationDate` string.
+ *
+ * Fails loudly: a missing/unresolvable timestamp is a programming error
+ * (every replayed action carries one), not a recoverable fallback.
+ */
+export const deriveCreationTimestampMs = (
+  ts: FirestoreTimestampLike,
+): number => {
+  const ms = toTimestampMs(ts);
+  if (ms === null || !(ms > 0)) {
+    throw new Error(
+      `deriveCreationTimestampMs: timestamp not set (got ${JSON.stringify(ts)})`,
+    );
+  }
+  return ms;
+};
+
 export const toFirestoreTimestamp = (
   ts: FirestoreTimestampLike,
 ): FirestoreTimestamp | null => {

--- a/tests/immutability.test.ts
+++ b/tests/immutability.test.ts
@@ -6,7 +6,7 @@ import {
   archive_inventory,
   delete_empty_order,
   hide_archive,
-  inventory,
+  inventory as _inventory,
   initialState as inventoryInitialState,
   make_sales,
   new_order,
@@ -17,6 +17,16 @@ import {
   update_field,
   update_item,
 } from "$lib/inventory";
+// Fixtures omit the per-action timestamp that every replayed action
+// carries in production; stamp one (deriveCreationTimestampMs fails
+// loudly on a missing timestamp).
+const inventory = (s: any, a: any) =>
+  _inventory(
+    s,
+    a && typeof a === "object" && a.type && !("timestamp" in a)
+      ? { ...a, timestamp: { _seconds: 1_700_000_000, _nanoseconds: 0 } }
+      : a,
+  );
 import {
   create_name,
   names,

--- a/tests/inventory.test.ts
+++ b/tests/inventory.test.ts
@@ -5,7 +5,7 @@ import {
   delete_empty_order,
   hide_archive,
   initialState,
-  inventory,
+  inventory as _inventory,
   make_sales,
   new_order,
   package_item,
@@ -17,6 +17,16 @@ import {
   type Item,
 } from "$lib/inventory";
 
+// Fixtures omit the per-action timestamp that every replayed action
+// carries in production; stamp one (deriveCreationTimestampMs fails
+// loudly on a missing timestamp).
+const inventory = (s: any, a: any) =>
+  _inventory(
+    s,
+    a && typeof a === "object" && a.type && !("timestamp" in a)
+      ? { ...a, timestamp: { _seconds: 1_700_000_000, _nanoseconds: 0 } }
+      : a,
+  );
 describe("inventory reducer", () => {
   describe("update_item", () => {
     it("adds a new item to the inventory", () => {

--- a/tests/shopify-sync.test.ts
+++ b/tests/shopify-sync.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { makeInventoryItemKey } from "$lib/sku";
 import {
   initialState,
-  inventory,
+  inventory as _inventory,
   shopify_order_created,
   shopify_order_updated,
   shopify_order_cancelled,
@@ -17,6 +17,16 @@ import {
   type InventoryItemKey,
 } from "$lib/inventory";
 
+// Fixtures omit the per-action timestamp that every replayed action
+// carries in production; stamp one (deriveCreationTimestampMs fails
+// loudly on a missing timestamp).
+const inventory = (s: any, a: any) =>
+  _inventory(
+    s,
+    a && typeof a === "object" && a.type && !("timestamp" in a)
+      ? { ...a, timestamp: { _seconds: 1_700_000_000, _nanoseconds: 0 } }
+      : a,
+  );
 describe("Shopify Sync Reducer", () => {
   const withBroadcastMeta = <T extends { type: string }>(
     action: T,

--- a/tests/unit/add-variant-dispatch-order.test.ts
+++ b/tests/unit/add-variant-dispatch-order.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it } from "vitest";
 
-import { rootReducer } from "$lib/root-reducer";
+import { rootReducer as _rootReducer } from "$lib/root-reducer";
+// Fixtures omit the per-action timestamp that every replayed action
+// carries in production; stamp one (deriveCreationTimestampMs fails
+// loudly on a missing timestamp).
+const rootReducer = (s: any, a: any) =>
+  _rootReducer(
+    s,
+    a && typeof a === "object" && a.type && !("timestamp" in a)
+      ? { ...a, timestamp: { _seconds: 1_700_000_000, _nanoseconds: 0 } }
+      : a,
+  );
 import { update_field, update_item, type Item } from "$lib/inventory";
 
 // onConfirmAddVariant in src/routes/listing-detail/+page.svelte's live-mode

--- a/tests/unit/cost-engine.test.ts
+++ b/tests/unit/cost-engine.test.ts
@@ -4,6 +4,7 @@ import {
   valueAt,
   totalValuation,
   UNKNOWN_RECEIPT_DATE,
+  parseReceiptDate,
   type LedgerEntry,
 } from "$lib/cost-engine";
 
@@ -111,6 +112,16 @@ describe("cost-engine", () => {
     const t = totalValuation([itemA, itemB]);
     expect(t.valueJpy).toBe(1000 + 3 * 50);
     expect(t.valueEur).toBeCloseTo(10 + 3 * 0.4, 9);
+  });
+
+  it("parseReceiptDate strips the (n) marker and falls back safely", () => {
+    expect(parseReceiptDate("Oct 9, 2024 (30)")).toBe(
+      Date.parse("Oct 9, 2024"),
+    );
+    expect(parseReceiptDate("Nov 9, 2023")).toBe(Date.parse("Nov 9, 2023"));
+    expect(parseReceiptDate("")).toBe(UNKNOWN_RECEIPT_DATE);
+    expect(parseReceiptDate(undefined)).toBe(UNKNOWN_RECEIPT_DATE);
+    expect(parseReceiptDate("garbage")).toBe(UNKNOWN_RECEIPT_DATE);
   });
 
   it("UNKNOWN_RECEIPT_DATE is a normal date the engine does not special-case", () => {

--- a/tests/unit/cost-engine.test.ts
+++ b/tests/unit/cost-engine.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import {
+  walkLedger,
+  valueAt,
+  totalValuation,
+  UNKNOWN_RECEIPT_DATE,
+  type LedgerEntry,
+} from "$lib/cost-engine";
+
+// See docs/investigations/DESIGN_INVENTORY_COST_AND_VALUATION.md
+
+const r = (
+  at: number,
+  qty: number,
+  jpy: number,
+  eur: number,
+  seq = 0,
+): LedgerEntry => ({
+  kind: "receipt",
+  at,
+  seq,
+  qty,
+  unitCostJpy: jpy,
+  unitCostEur: eur,
+});
+const s = (at: number, qty: number, seq = 0): LedgerEntry => ({
+  kind: "sale",
+  at,
+  seq,
+  qty,
+});
+
+describe("cost-engine", () => {
+  it("empty ledger -> zeros", () => {
+    expect(walkLedger([])).toEqual({ onHand: 0, avgJpy: 0, avgEur: 0 });
+  });
+
+  it("single receipt bootstraps the average", () => {
+    expect(walkLedger([r(1, 10, 282.7, 2.1)])).toEqual({
+      onHand: 10,
+      avgJpy: 282.7,
+      avgEur: 2.1,
+    });
+  });
+
+  it("blends receipts qty-weighted, JPY and EUR independently", () => {
+    const w = walkLedger([r(1, 10, 100, 0.8), r(2, 10, 75, 0.6)]);
+    expect(w.onHand).toBe(20);
+    expect(w.avgJpy).toBeCloseTo((10 * 100 + 10 * 75) / 20, 9); // 87.5
+    expect(w.avgEur).toBeCloseTo((10 * 0.8 + 10 * 0.6) / 20, 9); // 0.7
+  });
+
+  it("a sale reduces on-hand and leaves the average unchanged", () => {
+    const w = walkLedger([r(1, 10, 100, 1), s(2, 4)]);
+    expect(w).toEqual({ onHand: 6, avgJpy: 100, avgEur: 1 });
+  });
+
+  it("ORDER MATTERS: sale before a re-order blends against reduced on-hand", () => {
+    // sale-then-reorder: 10@100, sell 8, +10@75 -> (2*100+10*75)/12
+    const interleaved = walkLedger([
+      r(1, 10, 100, 1),
+      s(2, 8),
+      r(3, 10, 75, 0.7),
+    ]);
+    expect(interleaved.onHand).toBe(12);
+    expect(interleaved.avgJpy).toBeCloseTo((2 * 100 + 10 * 75) / 12, 9); // 79.166…
+
+    // reorder-then-sale: both receipts first -> 87.5, then sell 8
+    const grouped = walkLedger([r(1, 10, 100, 1), r(2, 10, 75, 0.7), s(3, 8)]);
+    expect(grouped.onHand).toBe(12);
+    expect(grouped.avgJpy).toBeCloseTo(87.5, 9);
+
+    expect(interleaved.avgJpy).not.toBeCloseTo(grouped.avgJpy, 5);
+  });
+
+  it("as-of truncation: only entries dated <= asOf are folded", () => {
+    const led = [r(100, 10, 100, 1), s(200, 5), r(300, 10, 50, 0.5)];
+    expect(walkLedger(led, 50)).toEqual({ onHand: 0, avgJpy: 0, avgEur: 0 });
+    expect(walkLedger(led, 100)).toEqual({
+      onHand: 10,
+      avgJpy: 100,
+      avgEur: 1,
+    });
+    expect(walkLedger(led, 250)).toEqual({ onHand: 5, avgJpy: 100, avgEur: 1 });
+    const all = walkLedger(led, 300);
+    expect(all.onHand).toBe(15);
+    expect(all.avgJpy).toBeCloseTo((5 * 100 + 10 * 50) / 15, 9);
+  });
+
+  it("is input-order independent given (at, seq)", () => {
+    const a = r(100, 10, 100, 1, 0);
+    const b = r(100, 5, 200, 2, 1); // same date, later seq
+    expect(walkLedger([a, b])).toEqual(walkLedger([b, a]));
+    // seq 0 establishes basis, seq 1 blends
+    const w = walkLedger([b, a]);
+    expect(w.avgJpy).toBeCloseTo((10 * 100 + 5 * 200) / 15, 9);
+  });
+
+  it("a sale cannot drive on-hand negative (oversell clamps at 0)", () => {
+    const w = walkLedger([r(1, 5, 100, 1), s(2, 9)]);
+    expect(w.onHand).toBe(0);
+    expect(w.avgJpy).toBe(100);
+  });
+
+  it("valueAt = on-hand × average; totalValuation sums items", () => {
+    const itemA = [r(1, 10, 100, 1)];
+    const itemB = [r(1, 4, 50, 0.4), s(2, 1)];
+    const va = valueAt(itemA);
+    expect(va.valueJpy).toBe(1000);
+    expect(va.valueEur).toBe(10);
+    const t = totalValuation([itemA, itemB]);
+    expect(t.valueJpy).toBe(1000 + 3 * 50);
+    expect(t.valueEur).toBeCloseTo(10 + 3 * 0.4, 9);
+  });
+
+  it("UNKNOWN_RECEIPT_DATE is a normal date the engine does not special-case", () => {
+    expect(UNKNOWN_RECEIPT_DATE).toBe(Date.UTC(2026, 0, 1));
+    const w = walkLedger([
+      r(UNKNOWN_RECEIPT_DATE, 10, 100, 1),
+      r(UNKNOWN_RECEIPT_DATE + 1000, 10, 200, 2, 1),
+    ]);
+    expect(w.onHand).toBe(20);
+    expect(w.avgJpy).toBeCloseTo(150, 9);
+  });
+});

--- a/tests/unit/cost-engine.test.ts
+++ b/tests/unit/cost-engine.test.ts
@@ -4,7 +4,6 @@ import {
   valueAt,
   totalValuation,
   UNKNOWN_RECEIPT_DATE,
-  parseReceiptDate,
   type LedgerEntry,
 } from "$lib/cost-engine";
 
@@ -112,16 +111,6 @@ describe("cost-engine", () => {
     const t = totalValuation([itemA, itemB]);
     expect(t.valueJpy).toBe(1000 + 3 * 50);
     expect(t.valueEur).toBeCloseTo(10 + 3 * 0.4, 9);
-  });
-
-  it("parseReceiptDate strips the (n) marker and falls back safely", () => {
-    expect(parseReceiptDate("Oct 9, 2024 (30)")).toBe(
-      Date.parse("Oct 9, 2024"),
-    );
-    expect(parseReceiptDate("Nov 9, 2023")).toBe(Date.parse("Nov 9, 2023"));
-    expect(parseReceiptDate("")).toBe(UNKNOWN_RECEIPT_DATE);
-    expect(parseReceiptDate(undefined)).toBe(UNKNOWN_RECEIPT_DATE);
-    expect(parseReceiptDate("garbage")).toBe(UNKNOWN_RECEIPT_DATE);
   });
 
   it("UNKNOWN_RECEIPT_DATE is a normal date the engine does not special-case", () => {

--- a/tests/unit/cost-ledger-reducer.test.ts
+++ b/tests/unit/cost-ledger-reducer.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from "vitest";
+import { rootReducer } from "$lib/root-reducer";
+import {
+  update_item,
+  bulk_import_items,
+  fix_jancode,
+  type Item,
+} from "$lib/inventory";
+
+// M2: `cost` is derived from the per-item costLedger materialised in
+// applyInventoryUpdate. Single priced lot -> cost == that lot (identical
+// to old last-write). A genuine stock-order re-order appends a second
+// lot -> receipt-weighted blend. Ledger follows the item across re-key.
+// See docs/investigations/DESIGN_INVENTORY_COST_AND_VALUATION.md
+
+function withTs(action: any, seconds: number) {
+  return { ...action, timestamp: { _seconds: seconds, _nanoseconds: 0 } };
+}
+
+const JAN = "4542804109245";
+const KEY = `${JAN}Blue`;
+
+const baseItem = (qty: number, extra: Partial<Item> = {}): Item => ({
+  janCode: JAN,
+  subtype: "Blue",
+  description: "Amifa Sticker",
+  hsCode: "48211010",
+  image: "",
+  qty,
+  pieces: 1,
+  shipped: 0,
+  creationDate: "Nov 9, 2023 (6)",
+  timestamp: 0,
+  ...extra,
+});
+
+describe("cost-ledger materialisation in the reducer", () => {
+  it("single priced lot derives the attached cost (unchanged vs last-write)", () => {
+    let s = rootReducer(undefined, { type: "@@INIT" });
+    s = rootReducer(
+      s,
+      withTs(update_item({ id: KEY, item: baseItem(6) }), 100),
+    );
+    // no cost yet -> unpriced single lot -> cost stays undefined
+    expect(s.inventory.idToItem[KEY].cost).toBeUndefined();
+    expect(s.inventory.costLedger![KEY]).toHaveLength(1);
+
+    // Original order (qty 0) attaches landed cost ¥65.
+    s = rootReducer(
+      s,
+      withTs(
+        bulk_import_items({
+          items: [
+            {
+              type: "update",
+              id: KEY,
+              item: baseItem(0),
+              stockOrder: {
+                orderId: "order-1",
+                unitCostJpy: 65,
+                unitCostEur: 0,
+                receivedAt: Date.parse("Nov 9, 2023"),
+              },
+            },
+          ],
+        }),
+        200,
+      ),
+    );
+    expect(s.inventory.idToItem[KEY].cost).toBe(65);
+    expect(s.inventory.costLedger![KEY]).toHaveLength(1);
+  });
+
+  it("a stock-order re-order appends a lot and blends qty-weighted", () => {
+    let s = rootReducer(undefined, { type: "@@INIT" });
+    s = rootReducer(
+      s,
+      withTs(update_item({ id: KEY, item: baseItem(6) }), 100),
+    );
+    s = rootReducer(
+      s,
+      withTs(
+        bulk_import_items({
+          items: [
+            {
+              type: "update",
+              id: KEY,
+              item: baseItem(0),
+              stockOrder: {
+                orderId: "o1",
+                unitCostJpy: 65,
+                unitCostEur: 0,
+                receivedAt: Date.parse("Nov 9, 2023"),
+              },
+            },
+          ],
+        }),
+        200,
+      ),
+    );
+    // Re-order: +12 units @ ¥62.
+    s = rootReducer(
+      s,
+      withTs(
+        bulk_import_items({
+          items: [
+            {
+              type: "update",
+              id: KEY,
+              item: baseItem(12),
+              stockOrder: {
+                orderId: "o2",
+                unitCostJpy: 62,
+                unitCostEur: 0,
+                receivedAt: Date.parse("Mar 2, 2026"),
+              },
+            },
+          ],
+        }),
+        300,
+      ),
+    );
+    const led = s.inventory.costLedger![KEY];
+    expect(led).toHaveLength(2);
+    expect(led.map((e: any) => [e.kind, e.qty, e.unitCostJpy])).toEqual([
+      ["receipt", 6, 65],
+      ["receipt", 12, 62],
+    ]);
+    // (6*65 + 12*62) / 18 = 63
+    expect(s.inventory.idToItem[KEY].cost).toBeCloseTo(63, 9);
+    expect(s.inventory.idToItem[KEY].qty).toBe(18);
+  });
+
+  it("the ledger follows the item across a JAN re-key", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      let s = rootReducer(undefined, { type: "@@INIT" });
+      s = rootReducer(
+        s,
+        withTs(update_item({ id: KEY, item: baseItem(6) }), 100),
+      );
+      s = rootReducer(
+        s,
+        withTs(
+          bulk_import_items({
+            items: [
+              {
+                type: "update",
+                id: KEY,
+                item: baseItem(12, { cost: undefined }),
+                stockOrder: {
+                  orderId: "o2",
+                  unitCostJpy: 62,
+                  unitCostEur: 0,
+                  receivedAt: Date.parse("Mar 2, 2026"),
+                },
+              },
+            ],
+          }),
+          200,
+        ),
+      );
+      // First lot unpriced (6@0), re-order lot 12@62 -> avg = 744/18
+      const before = s.inventory.idToItem[KEY].cost;
+      expect(before).toBeCloseTo((12 * 62) / 18, 9);
+
+      const NEWJAN = "4542804109999";
+      const NEWKEY = `${NEWJAN}Blue`;
+      s = rootReducer(
+        s,
+        withTs(fix_jancode({ itemKey: KEY as any, newJanCode: NEWJAN }), 300),
+      );
+      expect(s.inventory.costLedger![KEY]).toBeUndefined();
+      expect(s.inventory.costLedger![NEWKEY]).toHaveLength(2);
+      expect(s.inventory.idToItem[NEWKEY].cost).toBeCloseTo((12 * 62) / 18, 9);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+});

--- a/tests/unit/derive-creation-timestamp.test.ts
+++ b/tests/unit/derive-creation-timestamp.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { deriveCreationTimestampMs } from "$lib/timestamped-action";
+
+// Single source of truth for "when was this created": derive from the
+// action timestamp, never parse a formatted creationDate string. Fails
+// loudly when the timestamp is absent (a programming error).
+
+describe("deriveCreationTimestampMs", () => {
+  it("resolves every timestamp shape used in the codebase", () => {
+    expect(deriveCreationTimestampMs(1_700_000_000_000)).toBe(
+      1_700_000_000_000,
+    );
+    expect(deriveCreationTimestampMs({ seconds: 1_700, nanoseconds: 0 })).toBe(
+      1_700_000,
+    );
+    expect(
+      deriveCreationTimestampMs({ _seconds: 1_700, _nanoseconds: 0 }),
+    ).toBe(1_700_000);
+    const d = new Date("2024-10-09T00:00:00Z");
+    expect(deriveCreationTimestampMs({ toDate: () => d })).toBe(d.getTime());
+  });
+
+  it("throws loudly when the timestamp is not set", () => {
+    expect(() => deriveCreationTimestampMs(undefined)).toThrow(
+      /timestamp not set/,
+    );
+    expect(() => deriveCreationTimestampMs(null)).toThrow(/timestamp not set/);
+    expect(() => deriveCreationTimestampMs({} as any)).toThrow(
+      /timestamp not set/,
+    );
+    expect(() => deriveCreationTimestampMs(0)).toThrow(/timestamp not set/);
+  });
+});

--- a/tests/unit/fix-jancode.test.ts
+++ b/tests/unit/fix-jancode.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { rootReducer } from "$lib/root-reducer";
+import { rootReducer as _rootReducer } from "$lib/root-reducer";
 import {
   fix_jancode,
   new_order,
@@ -11,6 +11,18 @@ import { categorize_photo } from "$lib/photos-slice";
 import { add_proposals_internal } from "$lib/listing-creation-slice";
 import { resolve_conflict as resolveOrderConflict } from "$lib/order-import-slice";
 import { resolve_conflict as resolveShopifyConflict } from "$lib/shopify-import-slice";
+
+// Every replayed action carries a timestamp in production; these
+// fixtures omit it, so stamp a fixed one (deriveCreationTimestampMs
+// fails loudly on a missing timestamp).
+const TS = { _seconds: 1_700_000_000, _nanoseconds: 0 };
+const rootReducer = (s: any, a: any) =>
+  _rootReducer(
+    s,
+    a && typeof a === "object" && a.type && !("timestamp" in a)
+      ? { ...a, timestamp: TS }
+      : a,
+  );
 
 describe("fix_jancode", () => {
   it("re-keys inventory and dependent references without requiring an order retype flow", () => {

--- a/tests/unit/listing-creation-approve.test.ts
+++ b/tests/unit/listing-creation-approve.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it, vi } from "vitest";
 import { configureStore } from "@reduxjs/toolkit";
-import { rootReducer } from "$lib/root-reducer";
+import { rootReducer as _rootReducer } from "$lib/root-reducer";
+// Fixtures omit the per-action timestamp that every replayed action
+// carries in production; stamp one (deriveCreationTimestampMs fails
+// loudly on a missing timestamp).
+const rootReducer = (s: any, a: any) =>
+  _rootReducer(
+    s,
+    a && typeof a === "object" && a.type && !("timestamp" in a)
+      ? { ...a, timestamp: { _seconds: 1_700_000_000, _nanoseconds: 0 } }
+      : a,
+  );
 import {
   approve_proposal_thunk,
   add_proposals_internal,

--- a/tests/unit/listing-creation-split.test.ts
+++ b/tests/unit/listing-creation-split.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it } from "vitest";
 import { configureStore } from "@reduxjs/toolkit";
-import { rootReducer } from "../../src/lib/root-reducer";
+import { rootReducer as _rootReducer } from "../../src/lib/root-reducer";
+// Fixtures omit the per-action timestamp that every replayed action
+// carries in production; stamp one (deriveCreationTimestampMs fails
+// loudly on a missing timestamp).
+const rootReducer = (s: any, a: any) =>
+  _rootReducer(
+    s,
+    a && typeof a === "object" && a.type && !("timestamp" in a)
+      ? { ...a, timestamp: { _seconds: 1_700_000_000, _nanoseconds: 0 } }
+      : a,
+  );
 import {
   approve_proposal_thunk,
   add_proposals_internal,

--- a/tests/unit/listing-creation-variants.test.ts
+++ b/tests/unit/listing-creation-variants.test.ts
@@ -1,7 +1,17 @@
 import { describe, expect, it, beforeAll } from "vitest";
 import { configureStore } from "@reduxjs/toolkit";
 import { setAutoFreeze } from "immer";
-import { rootReducer } from "../../src/lib/root-reducer";
+import { rootReducer as _rootReducer } from "../../src/lib/root-reducer";
+// Fixtures omit the per-action timestamp that every replayed action
+// carries in production; stamp one (deriveCreationTimestampMs fails
+// loudly on a missing timestamp).
+const rootReducer = (s: any, a: any) =>
+  _rootReducer(
+    s,
+    a && typeof a === "object" && a.type && !("timestamp" in a)
+      ? { ...a, timestamp: { _seconds: 1_700_000_000, _nanoseconds: 0 } }
+      : a,
+  );
 import {
   set_proposal_handle_thunk,
   add_proposals_internal,

--- a/tests/unit/listing-handle-sync.test.ts
+++ b/tests/unit/listing-handle-sync.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { rootReducer } from "$lib/root-reducer";
+import { rootReducer as _rootReducer } from "$lib/root-reducer";
+// Fixtures omit the per-action timestamp that every replayed action
+// carries in production; stamp one (deriveCreationTimestampMs fails
+// loudly on a missing timestamp).
+const rootReducer = (s: any, a: any) =>
+  _rootReducer(
+    s,
+    a && typeof a === "object" && a.type && !("timestamp" in a)
+      ? { ...a, timestamp: { _seconds: 1_700_000_000, _nanoseconds: 0 } }
+      : a,
+  );
 import { update_field, update_item, type Item } from "$lib/inventory";
 
 describe("inventory handle updates sync to listings", () => {

--- a/tests/unit/listing-handle-update.test.ts
+++ b/tests/unit/listing-handle-update.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { rootReducer } from "$lib/root-reducer";
+import { rootReducer as _rootReducer } from "$lib/root-reducer";
+// Fixtures omit the per-action timestamp that every replayed action
+// carries in production; stamp one (deriveCreationTimestampMs fails
+// loudly on a missing timestamp).
+const rootReducer = (s: any, a: any) =>
+  _rootReducer(
+    s,
+    a && typeof a === "object" && a.type && !("timestamp" in a)
+      ? { ...a, timestamp: { _seconds: 1_700_000_000, _nanoseconds: 0 } }
+      : a,
+  );
 import { update_item, update_field, type Item } from "$lib/inventory";
 
 describe("listing handle update logic", () => {

--- a/tests/unit/listing-title-sync.test.ts
+++ b/tests/unit/listing-title-sync.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { rootReducer } from "$lib/root-reducer";
+import { rootReducer as _rootReducer } from "$lib/root-reducer";
+// Fixtures omit the per-action timestamp that every replayed action
+// carries in production; stamp one (deriveCreationTimestampMs fails
+// loudly on a missing timestamp).
+const rootReducer = (s: any, a: any) =>
+  _rootReducer(
+    s,
+    a && typeof a === "object" && a.type && !("timestamp" in a)
+      ? { ...a, timestamp: { _seconds: 1_700_000_000, _nanoseconds: 0 } }
+      : a,
+  );
 import { update_field, update_item } from "$lib/inventory";
 import { create_listing, update_listing } from "$lib/listings-slice";
 

--- a/tests/unit/order-import-cost.test.ts
+++ b/tests/unit/order-import-cost.test.ts
@@ -40,4 +40,31 @@ describe("order import populates cost on NEW items", () => {
     expect(item.qty).toBe(12);
     expect(item.cost).toBe(62);
   });
+
+  it("derives per-unit cost as Total Wholesale ÷ PCS when no unit-price column (M3a)", () => {
+    const JAN2 = "4542804188888";
+    // No unit-price column; UNIT (4) must be disregarded -> 4700/20 = 235.
+    const csv = [
+      "JAN code,Product name,Order Q'ty Unit,Order Q'ty PCS,Total Wholesale Amount YEN",
+      `${JAN2},Letter Set, 4 , 20 ," 4,700 "`,
+    ].join("\n");
+    let s = rootReducer(undefined, { type: "@@INIT" });
+    s = rootReducer(s, {
+      ...start_session({ id: "f2", name: "senshu.csv" }),
+      timestamp: TS,
+    } as any);
+    s = rootReducer(s, {
+      ...append_raw_rows({ rawRows: csv, done: true }),
+      timestamp: TS,
+    } as any);
+    s = rootReducer(s, {
+      ...import_batch({ filter: "NEW" }),
+      timestamp: TS,
+    } as any);
+
+    const item = s.inventory.idToItem[JAN2];
+    expect(item).toBeDefined();
+    expect(item.qty).toBe(20);
+    expect(item.cost).toBe(235);
+  });
 });

--- a/tests/unit/replay-toile.test.ts
+++ b/tests/unit/replay-toile.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { rootReducer } from "$lib/root-reducer";
+import { rootReducer as _rootReducer } from "$lib/root-reducer";
+// Fixtures omit the per-action timestamp that every replayed action
+// carries in production; stamp one (deriveCreationTimestampMs fails
+// loudly on a missing timestamp).
+const rootReducer = (s: any, a: any) =>
+  _rootReducer(
+    s,
+    a && typeof a === "object" && a.type && !("timestamp" in a)
+      ? { ...a, timestamp: { _seconds: 1_700_000_000, _nanoseconds: 0 } }
+      : a,
+  );
 import { makeInventoryItemKey } from "$lib/sku";
 import { readFileSync } from "fs";
 import { join } from "path";

--- a/tests/unit/shiba-ziplock-qty-replay.test.ts
+++ b/tests/unit/shiba-ziplock-qty-replay.test.ts
@@ -2,7 +2,17 @@ import { describe, expect, it } from "vitest";
 import { readFileSync } from "fs";
 import { join } from "path";
 
-import { rootReducer } from "$lib/root-reducer";
+import { rootReducer as _rootReducer } from "$lib/root-reducer";
+// Fixtures omit the per-action timestamp that every replayed action
+// carries in production; stamp one (deriveCreationTimestampMs fails
+// loudly on a missing timestamp).
+const rootReducer = (s: any, a: any) =>
+  _rootReducer(
+    s,
+    a && typeof a === "object" && a.type && !("timestamp" in a)
+      ? { ...a, timestamp: { _seconds: 1_700_000_000, _nanoseconds: 0 } }
+      : a,
+  );
 import { makeInventoryItemKey } from "$lib/sku";
 import { update_item, type Item } from "$lib/inventory";
 

--- a/tests/unit/shopify-image-migration-rewrite.test.ts
+++ b/tests/unit/shopify-image-migration-rewrite.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { rootReducer } from "../../src/lib/root-reducer";
+import { rootReducer as _rootReducer } from "../../src/lib/root-reducer";
+// Fixtures omit the per-action timestamp that every replayed action
+// carries in production; stamp one (deriveCreationTimestampMs fails
+// loudly on a missing timestamp).
+const rootReducer = (s: any, a: any) =>
+  _rootReducer(
+    s,
+    a && typeof a === "object" && a.type && !("timestamp" in a)
+      ? { ...a, timestamp: { _seconds: 1_700_000_000, _nanoseconds: 0 } }
+      : a,
+  );
 import { update_item } from "../../src/lib/inventory";
 import { create_listing } from "../../src/lib/listings-slice";
 

--- a/tests/unit/shopify-import-listing-images.test.ts
+++ b/tests/unit/shopify-import-listing-images.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { rootReducer } from "../../src/lib/root-reducer";
+import { rootReducer as _rootReducer } from "../../src/lib/root-reducer";
+// Fixtures omit the per-action timestamp that every replayed action
+// carries in production; stamp one (deriveCreationTimestampMs fails
+// loudly on a missing timestamp).
+const rootReducer = (s: any, a: any) =>
+  _rootReducer(
+    s,
+    a && typeof a === "object" && a.type && !("timestamp" in a)
+      ? { ...a, timestamp: { _seconds: 1_700_000_000, _nanoseconds: 0 } }
+      : a,
+  );
 import {
   append_raw_rows,
   import_batch,

--- a/tests/unit/stock-order-cost.test.ts
+++ b/tests/unit/stock-order-cost.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseStockOrderUnitCostJpy,
+  parseAmount,
+  normalizeHeader,
+  STOCK_ORDER_UNIT_COST_UNKNOWN,
+} from "$lib/stock-order-cost";
+
+// See docs/investigations/DESIGN_INVENTORY_COST_AND_VALUATION.md §6.2
+
+describe("parseAmount", () => {
+  it("strips formatting", () => {
+    expect(parseAmount(" 4,700 ")).toBe(4700);
+    expect(parseAmount("¥1,234.5")).toBe(1234.5);
+    expect(parseAmount(282.7)).toBe(282.7);
+    expect(parseAmount("-12")).toBe(-12);
+  });
+  it("returns NaN for empty/garbage", () => {
+    expect(Number.isNaN(parseAmount(""))).toBe(true);
+    expect(Number.isNaN(parseAmount("  "))).toBe(true);
+    expect(Number.isNaN(parseAmount(undefined))).toBe(true);
+    expect(Number.isNaN(parseAmount(Number.NaN))).toBe(true);
+  });
+});
+
+describe("normalizeHeader", () => {
+  it("lowercases and drops non-alphanumerics incl. newlines", () => {
+    expect(normalizeHeader("ORDER \nQ'ty PCS")).toBe("orderqtypcs");
+    expect(normalizeHeader("Total Wholesale Amount YEN")).toBe(
+      "totalwholesaleamountyen",
+    );
+    expect(normalizeHeader("UNIT PRICE (YEN)")).toBe("unitpriceyen");
+  });
+});
+
+describe("parseStockOrderUnitCostJpy", () => {
+  it("Total Wholesale ÷ PCS, disregarding Q'ty UNIT (Senshu-style)", () => {
+    const headers = [
+      "JAN code",
+      "Order Q'ty Unit",
+      "Order Q'ty PCS",
+      "Total Wholesale Amount YEN",
+    ];
+    // UNIT=4 must be ignored; 4700 / 20 = 235  (NOT 4700/(20*4)=58.75)
+    const row = ["4952270317561", " 4 ", " 20 ", '" 4,700 "'];
+    expect(parseStockOrderUnitCostJpy(headers, row)).toBeCloseTo(235, 9);
+  });
+
+  it("uses an explicit per-unit price column when finite", () => {
+    const headers = [
+      "Bar-Code No.",
+      "Q'ty per UNIT",
+      "UNIT PRICE (YEN)",
+      "ORDER \nQ'ty UNIT",
+      "ORDER \nQ'ty PCS",
+      "Total Wholesale Amount YEN",
+    ];
+    const row = ["4542804103342", "6", " 35 ", "4", "30", " 1,050 "];
+    // explicit price 35 wins; not confused by "Q'ty per UNIT"/"ORDER Q'ty UNIT"
+    expect(parseStockOrderUnitCostJpy(headers, row)).toBe(35);
+  });
+
+  it("falls back to total ÷ pcs when explicit price is blank/zero", () => {
+    const headers = [
+      "UNIT PRICE (YEN)",
+      "ORDER \nQ'ty PCS",
+      "Total Wholesale Amount YEN",
+    ];
+    expect(
+      parseStockOrderUnitCostJpy(
+        ["UNIT PRICE (YEN)", "ORDER \nQ'ty PCS", "Total Wholesale Amount YEN"],
+        ["", "10", "1000"],
+      ),
+    ).toBe(100);
+    expect(parseStockOrderUnitCostJpy(headers, [" 0 ", "10", "1000"])).toBe(
+      100,
+    );
+  });
+
+  it("returns the unknown sentinel when not computable", () => {
+    const headers = [
+      "JAN code",
+      "Order Q'ty PCS",
+      "Total Wholesale Amount YEN",
+    ];
+    expect(parseStockOrderUnitCostJpy(headers, ["x", "0", "1000"])).toBe(
+      STOCK_ORDER_UNIT_COST_UNKNOWN,
+    );
+    expect(parseStockOrderUnitCostJpy(headers, ["x", "", ""])).toBe(
+      STOCK_ORDER_UNIT_COST_UNKNOWN,
+    );
+    expect(parseStockOrderUnitCostJpy(["A", "B"], ["1", "2"])).toBe(
+      STOCK_ORDER_UNIT_COST_UNKNOWN,
+    );
+  });
+
+  it("handles a newline inside the PCS header", () => {
+    const headers = ["ORDER \nQ'ty PCS", "Total Wholesale Amount YEN"];
+    expect(parseStockOrderUnitCostJpy(headers, ["20", "5000"])).toBe(250);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the data layer of `docs/investigations/DESIGN_INVENTORY_COST_AND_VALUATION.md`. `cost` is no longer last-write — it is **derived** from a per-item `costLedger` (receipts + dated sales, perpetual weighted-average) materialised by the existing reducers during replay.

- **M1** — pure `cost-engine.ts` (date-sorted ledger walk, dual-currency JPY/EUR, as-of truncation, `UNKNOWN_RECEIPT_DATE`) + `stock-order-cost.ts` (`Total Wholesale ÷ Order Q'ty PCS`, UNIT disregarded; explicit unit-price wins).
- **M2** — ledger materialised in `applyInventoryUpdate`: creation → lot 1; original stock order (qty 0) attaches landed cost; genuine re-order (delta>0) appends a dated lot. Follows the item across bare-JAN canonicalisation, subtype merges, `fix_jancode`, splits. Stock-order registry + `set_stock_order_meta` action. Schema bumped to 5.
- **M2b** — dated `sale` entries appended at the Shopify/Etsy reconciliation + `make_sales` outflow points, so the walk reduces on-hand before a re-order (sale-aware average).
- **M3a** — order-import (`mapImportItem`) now uses the M1 parser, so "new stock" lines with Total+PCS but no unit-price column import a real cost.

## Validation (full replay of production-backup-may-16)

- Deterministic across two cold cold replays; **0** re-key mis-blends.
- Single-receipt items byte-identical to old last-write (`Dinosaur` ¥35, on-hand 27 = 30 − 3 shipped).
- `Cat in Mug` 0 → **¥194** (zero-cost lot resolved by M3a); `Green` re-order lot 385 → 402 → sale-aware blend ¥395.97.
- **SKU Review COST: 246 → 183**; items-with-exceptions → 217. Remaining 183 are genuine data gaps (no supplier order, or no unit-price *and* no Total+PCS).
- 24 new/updated unit tests; full pre-commit + pre-push (E2E) green.

## Scope / follow-ups (not in this PR)

- M3 UI: `/received-inventory` screen (real receipt dates + JPY/EUR totals → real EUR + true re-order timeline), cost-exceptions surface.
- M5: valuation report (separate design).
- Live-event/package allocation nets to sales via the wired paths in this dataset; not separately ledgered.

## Test plan

- [x] `bun run test` (full unit suite) — green via pre-commit
- [x] Full E2E suite — green via pre-push
- [x] Full-replay before/after on production-backup-may-16 (determinism, invariant, SKU review)
- [ ] Reviewer: confirm the M2/M2b reducer materialisation points (§3) and the M2 invariant match intent

🤖 Generated with [Claude Code](https://claude.com/claude-code)