### PR TITLE
[codex] Fix completed photo group filtering

### DIFF
--- a/src/lib/photos-completion.ts
+++ b/src/lib/photos-completion.ts
@@ -1,0 +1,100 @@
+import type { Item } from "./inventory";
+import type { Listing, ListingsState } from "./listings-slice";
+
+interface InventoryLike {
+  idToItem?: Record<string, Item>;
+}
+
+interface CompletionIndexes {
+  exactListedKeys: Set<string>;
+  listedBaseJans: Set<string>;
+  inventorySubtypesByBaseJan: Map<string, Set<string>>;
+  completedOptionKeys: Set<string>;
+}
+
+function splitPhotoGroupKey(key: string): { baseJan: string; suffix: string } {
+  const [baseJan, ...rest] = String(key || "").split(":");
+  return { baseJan, suffix: rest.join(":").trim() };
+}
+
+function addCompletedListingKeysForItem(
+  indexes: CompletionIndexes,
+  itemId: string,
+  item: Item,
+  listing: Listing | undefined,
+) {
+  if (!item?.janCode || !listing?.bodyHtml) return;
+
+  indexes.listedBaseJans.add(item.janCode);
+  indexes.exactListedKeys.add(item.janCode);
+
+  const subtype = String(item.subtype || "").trim();
+  if (subtype) {
+    indexes.exactListedKeys.add(`${item.janCode}:${subtype}`);
+  }
+
+  const optionLabel = String(
+    listing.variantOptionsByItemId?.[itemId] || "",
+  ).trim();
+  if (optionLabel) {
+    indexes.completedOptionKeys.add(`${item.janCode}:${optionLabel}`);
+  }
+}
+
+export function buildCompletedPhotoGroupIndexes(
+  inventory: InventoryLike | undefined,
+  listings: Pick<ListingsState, "idToHandle" | "handleToListing"> | undefined,
+): CompletionIndexes {
+  const indexes: CompletionIndexes = {
+    exactListedKeys: new Set(),
+    listedBaseJans: new Set(),
+    inventorySubtypesByBaseJan: new Map(),
+    completedOptionKeys: new Set(),
+  };
+
+  const idToItem = inventory?.idToItem || {};
+  const idToHandle = listings?.idToHandle || {};
+  const handleToListing = listings?.handleToListing || {};
+
+  for (const [itemId, item] of Object.entries(idToItem)) {
+    if (!item?.janCode) continue;
+
+    const subtype = String(item.subtype || "").trim();
+    if (subtype) {
+      const subtypes =
+        indexes.inventorySubtypesByBaseJan.get(item.janCode) || new Set();
+      subtypes.add(subtype);
+      indexes.inventorySubtypesByBaseJan.set(item.janCode, subtypes);
+    }
+
+    const handle = idToHandle[itemId];
+    addCompletedListingKeysForItem(
+      indexes,
+      itemId,
+      item,
+      handle ? handleToListing[handle] : undefined,
+    );
+  }
+
+  return indexes;
+}
+
+export function isCompletedPhotoGroupKey(
+  photoGroupKey: string,
+  indexes: CompletionIndexes,
+): boolean {
+  if (indexes.exactListedKeys.has(photoGroupKey)) return true;
+  if (indexes.completedOptionKeys.has(photoGroupKey)) return true;
+
+  const { baseJan, suffix } = splitPhotoGroupKey(photoGroupKey);
+  if (!baseJan || !suffix || !indexes.listedBaseJans.has(baseJan)) {
+    return false;
+  }
+
+  const inventorySubtypes = indexes.inventorySubtypesByBaseJan.get(baseJan);
+  if (!inventorySubtypes || inventorySubtypes.size === 0) {
+    return true;
+  }
+
+  return !inventorySubtypes.has(suffix);
+}

--- a/src/routes/photos/+page.svelte
+++ b/src/routes/photos/+page.svelte
@@ -48,6 +48,10 @@
     setFilePermissions,
   } from "$lib/google-drive";
   import { shouldProcessPhotoFromHistory } from "$lib/photos-processing-eligibility";
+  import {
+    buildCompletedPhotoGroupIndexes,
+    isCompletedPhotoGroupKey,
+  } from "$lib/photos-completion";
   import SecureImage from "$lib/components/SecureImage.svelte";
   import ProcessingConfigModal from "$lib/components/ProcessingConfigModal.svelte";
   import { store } from "$lib/store";
@@ -1242,38 +1246,18 @@
     return `/photo-history?${params.toString()}`;
   }
 
-  // Compute Listed JANs
-  $: listedJans = (() => {
-    const listed = new Set<string>();
-    const idToHandle = $store.listings.idToHandle || {};
-    const idToItem = $store.inventory.idToItem || {};
-    const handleToListing = $store.listings.handleToListing || {};
-
-    // Iterate all items in inventory
-    for (const itemId in idToItem) {
-      const item = idToItem[itemId];
-      // Check if this item is linked to a listing
-      const handle = idToHandle[itemId];
-      const listing = handle ? handleToListing[handle] : null;
-
-      if (item && item.janCode && listing) {
-        // Only consider "Listed" if it has a bodyHtml (implying description generated/listing created)
-        if (listing.bodyHtml) {
-          // Add base JAN
-          listed.add(item.janCode);
-          // Add subtype-specific key if applicable
-          if (item.subtype) {
-            listed.add(`${item.janCode}:${item.subtype}`);
-          }
-        }
-      }
-    }
-    return listed;
-  })();
+  $: completedPhotoGroupIndexes = buildCompletedPhotoGroupIndexes(
+    $store.inventory,
+    $store.listings,
+  );
 
   $: categorizedEntries = (
     Object.entries(janCodeToPhotos) as [string, MediaItem[]][]
-  ).filter(([jan, _]) => showCompleted || !listedJans.has(jan));
+  ).filter(
+    ([jan, _]) =>
+      showCompleted ||
+      !isCompletedPhotoGroupKey(jan, completedPhotoGroupIndexes),
+  );
 
   // JAN Validation (EAN-13 Checksum)
   function isValidJan(code: string): boolean {

--- a/tests/unit/photos-completion.test.ts
+++ b/tests/unit/photos-completion.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCompletedPhotoGroupIndexes,
+  isCompletedPhotoGroupKey,
+} from "../../src/lib/photos-completion";
+
+function item(janCode: string, subtype = "") {
+  return {
+    janCode,
+    subtype,
+    qty: 1,
+    shipped: 0,
+    description: "",
+    image: "",
+    pieces: 1,
+  } as any;
+}
+
+function listing(optionLabels: Record<string, string> = {}) {
+  return {
+    handle: "listed-handle",
+    title: "Listed",
+    bodyHtml: "<p>Listed</p>",
+    productCategory: "",
+    productType: "",
+    vendor: "",
+    tags: [],
+    status: "active",
+    option1Name: "Subtype",
+    variantOptionsByItemId: optionLabels,
+    images: [],
+    lastUpdated: 1,
+  } as any;
+}
+
+describe("photos completion", () => {
+  it("marks exact bare and subtype photo groups complete", () => {
+    const indexes = buildCompletedPhotoGroupIndexes(
+      {
+        idToItem: {
+          "4901681382316Standard": item("4901681382316", "Standard"),
+        },
+      },
+      {
+        idToHandle: { "4901681382316Standard": "listed-handle" },
+        handleToListing: { "listed-handle": listing() },
+      },
+    );
+
+    expect(isCompletedPhotoGroupKey("4901681382316", indexes)).toBe(true);
+    expect(isCompletedPhotoGroupKey("4901681382316:Standard", indexes)).toBe(
+      true,
+    );
+  });
+
+  it("treats option-label photo groups as complete when the listed inventory item is bare", () => {
+    const indexes = buildCompletedPhotoGroupIndexes(
+      {
+        idToItem: {
+          "4901681382316": item("4901681382316"),
+        },
+      },
+      {
+        idToHandle: { "4901681382316": "listed-handle" },
+        handleToListing: {
+          "listed-handle": listing({ "4901681382316": "Standard" }),
+        },
+      },
+    );
+
+    expect(isCompletedPhotoGroupKey("4901681382316:Standard", indexes)).toBe(
+      true,
+    );
+    expect(isCompletedPhotoGroupKey("4901681382316:Dark", indexes)).toBe(true);
+  });
+
+  it("does not hide a real unlisted subtype just because a sibling base JAN is listed", () => {
+    const indexes = buildCompletedPhotoGroupIndexes(
+      {
+        idToItem: {
+          "4542804089301Blue": item("4542804089301", "Blue"),
+          "4542804089301Pink": item("4542804089301", "Pink"),
+        },
+      },
+      {
+        idToHandle: { "4542804089301Blue": "listed-handle" },
+        handleToListing: { "listed-handle": listing() },
+      },
+    );
+
+    expect(isCompletedPhotoGroupKey("4542804089301:Blue", indexes)).toBe(true);
+    expect(isCompletedPhotoGroupKey("4542804089301:Pink", indexes)).toBe(false);
+    expect(
+      isCompletedPhotoGroupKey("4542804089301:Display Label", indexes),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a shared photo group completion helper for the Photos screen.
- Treat listing option-label photo groups as completed when the base JAN is already listed as a bare inventory item.
- Keep real unlisted subtype groups visible so unfinished subtype work still surfaces.

## Root Cause
The Photos page hid completed groups by exact key only. After separating listing option labels from inventory subtypes, completed listings could leave photo groups such as `JAN:Standard` while the listed inventory item was the bare `JAN`, so those completed groups remained visible.

## Validation
- `bun test tests/unit/photos-completion.test.ts`
- `bunx svelte-check --tsconfig ./tsconfig.json`
- `bunx prettier --check src/lib/photos-completion.ts src/routes/photos/+page.svelte tests/unit/photos-completion.test.ts`
- Jun 23 production backup replay: visible completed-hidden photo groups dropped from 73 to 2; remaining rows are invalid/no-inventory groups.
- Pre-commit full Vitest coverage suite passed.
- Pre-push live fixture health check, live Vitest, live E2E, and non-live E2E passed.
