### PR TITLE
[codex] Fix subtype listing migration

### DIFF
--- a/docs/investigations/HANDLE_EDIT_NO_CREATE_DELETE_BLAST_RADIUS_JUN_27_2026.md
+++ b/docs/investigations/HANDLE_EDIT_NO_CREATE_DELETE_BLAST_RADIUS_JUN_27_2026.md
@@ -1,0 +1,258 @@
+# Inventory Updates Must Not Create Listings -- Jun 27 2026
+
+## Summary
+
+This report covers the working-tree change that enforces a stricter listing
+creation rule:
+
+> Inventory updates and handle edits must not create or delete listing rows.
+
+Expected listing creation paths are:
+
+- Shopify import / Shopify listing import.
+- Listing draft approval.
+- Explicit listing actions.
+
+The concrete problem example was
+`bag-ziplock-masterpiece-square-4542804119091`: this was not created by a
+Shopify import or a listing draft approval. It was synthesized by the old
+`update_item` replay path from the scanned inventory description
+`Bag Ziplock Masterpiece Square`.
+
+The attempted fix is now clean for accounting and inventory. It removes
+scan-synthesized local listing rows and preserves the real Shopify/imported
+listing rows. There are still listing-state diffs to review, especially one
+Love & Fur handle inconsistency that the old reducer was hiding.
+
+## Code Change
+
+The attempt changes the listing reducer and Shopify import orchestration:
+
+- `update_item` no longer creates `handleToListing` rows.
+- Generic `bulk_import_items` no longer creates `handleToListing` rows.
+- Those inventory actions may link an item only when the target listing row
+  already exists.
+- `update_field(handle)` no longer creates, moves, or deletes listing rows.
+- `update_field(handle)` preserves dormant option labels on the previous
+  listing so relinking does not degrade explicit option labels to `Default`.
+- Shopify import now emits explicit `create_listing` updates so Shopify import
+  remains a valid creation path without relying on inventory side effects.
+- Listing draft approval still creates/updates the approved listing, but no
+  longer deletes prior listing rows as incidental cleanup.
+
+## Blast Radius Command
+
+```bash
+npm run blast-radius -- compare \
+  --base HEAD \
+  --head working-tree \
+  --backup ../production-backup-jun-26-trace-4542804151626 \
+  --name no-inventory-listing-creation-jun27-v3
+```
+
+Artifacts:
+
+- Generated report: `.blastradius/runs/no-inventory-listing-creation-jun27-v3/report.md`
+- Exhaustive leaf diff: `.blastradius/runs/no-inventory-listing-creation-jun27-v3/report.full-state-diff.json`
+- Base replay: `.blastradius/runs/no-inventory-listing-creation-jun27-v3/bccaedd2fbf5.json`
+- Working-tree replay: `.blastradius/runs/no-inventory-listing-creation-jun27-v3/working-tree.json`
+
+For full Markdown detail:
+
+```bash
+bun scripts/inventory-replay-dump.ts diff \
+  .blastradius/runs/no-inventory-listing-creation-jun27-v3/bccaedd2fbf5.json \
+  .blastradius/runs/no-inventory-listing-creation-jun27-v3/working-tree.json \
+  --out .blastradius/runs/no-inventory-listing-creation-jun27-v3/report.full.md \
+  --detail-limit 0
+```
+
+## Validation
+
+Focused unit tests passed:
+
+```bash
+npm run test:unit -- \
+  tests/unit/listing-handle-update.test.ts \
+  tests/unit/listing-handle-sync.test.ts \
+  tests/unit/shopify-import-listing-images.test.ts
+```
+
+## Accounting And Inventory Impact
+
+No accounting, inventory, order, or valuation state changed.
+
+| Surface | Result |
+|---|---|
+| Actions replayed | `42,863 -> 42,863` |
+| `inventory.idToItem` | No changed keys; no added or removed items. |
+| `inventory.costLedger` | No changed keys; no added or removed entries. |
+| Order value summary | Rows changed: 0. Mismatch vector stayed `0, 9100, 0, 0, 0, 0`. |
+| Inventory value report | Rows changed: 0. Current residual JPY stayed `0`. |
+| Recount found stock | Rows changed: 0. Count stayed `0`. |
+| Average costs | 0 changes. |
+| Received cost basis | 0 changes. |
+| On-hand inventory value | JPY stayed `809,987.42`; EUR stayed `4,725.2897`. |
+
+This is the important positive result: the blast radius is confined to listing
+and photo state.
+
+## Full Redux Diff Coverage
+
+| Slice | Added leaves | Removed leaves | Changed leaves | Total | Judgment |
+|---|---:|---:|---:|---:|---|
+| `listings` | 41 | 6,142 | 34 | 6,217 | Expected area of impact. Requires product review. |
+| `photos` | 0 | 0 | 26 | 26 | Synthetic replay metadata churn already seen in prior reports. |
+| Other slices | 0 | 0 | 0 | 0 | Expected and good. |
+
+The 26 `photos` diffs are generated metadata differences. No listing image URL,
+inventory item, cost, order, or valuation result moved because of them.
+
+## Concrete Example Result
+
+### `bag-ziplock-masterpiece-square-4542804119091`
+
+This scan-generated local listing is gone after the fix.
+
+| State | Result |
+|---|---|
+| Before | No row in the current branch base replay. |
+| After | No row. |
+| Judgment | Good. The old scan-synthesized row is not recreated. |
+
+The active Shopify/imported listing remains intact:
+
+| Handle | Result |
+|---|---|
+| `amifa-masterpiece-collection-zipper-bag-4542804119091` | Exists before and after. |
+| Variants | `4542804119091Strawberry`, `4542804119091Roses` remain linked. |
+| Option labels | `Strawberry`, `Roses` remain present. |
+
+### `amifa-berry-cherry-wall-stickers-4542804113471`
+
+This was the prior handle-edit example. It stays correct.
+
+| Field | Before | After |
+|---|---|---|
+| Listing exists | yes | yes |
+| Linked item | `4542804113471` | `4542804113471` |
+| Option label | `red` | `red` |
+| Item handle | `amifa-berry-cherry-wall-stickers-4542804113471` | same |
+| Qty / shipped | `39 / 2` | same |
+| Cost / price | `35 JPY / EUR 4` | same |
+
+This confirms that preserving dormant option labels fixed the earlier
+`Default` regression.
+
+## Listing Row Impact
+
+| Metric | Before | After | Delta | Judgment |
+|---|---:|---:|---:|---|
+| Local `handleToListing` rows | 788 | 427 | -361 | Large but expected direction: scan-synthesized listings are no longer created. |
+| Removed local listing rows | 362 | - | - | Mostly generated inventory-scan listings. |
+| Added local listing rows | - | 1 | +1 | A listing draft approval row that no longer gets moved/deleted by later handle behavior. |
+| Changed local listing rows | 167 | - | - | Mostly option/index details on surviving real listings. |
+| Removed rows also present in Shopify catalog mirror | 1 | - | - | Needs review; see Love & Fur below. |
+
+The old local listing set had many rows that could only exist because
+`update_item` synthesized listings from inventory data. Examples of removed
+generated rows include:
+
+| Removed handle | Interpretation |
+|---|---|
+| `masking-label-stickers-48ct-4980299065828` | Generated inventory description handle. |
+| `fabric-stickers-11ct-4980299030451` | Generated inventory description handle. |
+| `b5-kraft-envelopes-10ct-4968583218556` | Generated inventory description handle. |
+| `bag-drawstring-nylon-4542804103892` | Generated inventory description handle. |
+| `bag-nylon-tulle-4542804115604` | Generated inventory description handle. |
+| `stickers-cats-striped-4580424666014` | Generated inventory description handle. |
+
+The full list is in the full diff artifact.
+
+## Listing Index Impact
+
+| Metric | Before | After | Delta | Judgment |
+|---|---:|---:|---:|---|
+| `idToHandle` entries | 1,254 | 837 | -417 | Expected direction: links to scan-synthesized local listing rows disappear. |
+| Added `idToHandle` entries | 0 | 0 | 0 | Expected. |
+| Changed `idToHandle` entries | 0 | 0 | 0 | Expected. |
+
+Unlike the earlier failed attempt, this run does not show broad active-listing
+link loss from Shopify import. The Shopify import order was corrected so
+explicit Shopify-created listings exist before inventory rows are re-linked.
+
+## Listing Detail / Variant Label Impact
+
+The blast-radius report derives listing-detail labels from the same state the
+UI uses.
+
+| Metric | Count | Judgment |
+|---|---:|---|
+| Listing-detail pages with variant label changes | 341 | Mostly removed generated local listing pages. |
+| New `Default` label regressions | 0 | Good. |
+| Listing variant/option leaf diffs | 494 | Expected surface to review. |
+
+Many changed rows have an empty “after” because the old page was a generated
+local listing that no longer exists. This is the desired class of cleanup, but
+the volume is large enough that product review is warranted before landing.
+
+## Open Concern: Love & Fur
+
+One removed local row also exists in the Shopify catalog mirror:
+
+`kyowa-kawaii-puppy-dog-love-fur-sticky-notes-77`
+
+Before the fix, local listing state had:
+
+- handle `kyowa-kawaii-puppy-dog-love-fur-sticky-notes-77`
+- title `Kyowa Love & Fur Dog Mini Sticky Notes (75)`
+- linked variants:
+  - `4969757171813Pomeranian`
+  - `4969757171813Poodle`
+  - `4969757171813Schnauzer`
+  - `4969757171813Shiba`
+
+After the fix:
+
+- the item records still have `item.handle =
+  kyowa-kawaii-puppy-dog-love-fur-sticky-notes-77`
+- the Shopify catalog mirror still has that handle
+- `listings.idToHandle` no longer links those items
+- the local listing row instead exists under
+  `kyowa-kawaii-puppy-dog-love-fur-sticky-notes-75-4969757171813`
+
+This relates to the earlier handle slug investigation documented in
+`docs/investigations/PROPOSAL_HANDLE_NOT_SLUGIFIED.md`.
+
+Interpretation: the old reducer hid this inconsistency by allowing inventory
+updates to synthesize or relink listing rows. The stricter rule exposes that
+the local listing approval/import history and the final Shopify/catalog handle
+do not agree.
+
+This should not be fixed by allowing `update_item` to create listings again.
+It needs an explicit policy:
+
+- either a Shopify catalog/import reconciliation should create/link the local
+  listing for `...-77`, or
+- the local listing approval path should be corrected to the canonical Shopify
+  handle, or
+- the item handles should be changed through an explicit operator action.
+
+## Landing Judgment
+
+| Area | Status | Reason |
+|---|---|---|
+| Inventory updates do not create listings | Good | `update_item`/generic `bulk_import_items` now only link to existing rows. |
+| Handle edits do not create/delete listing rows | Good | `applyHandleUpdate` no longer creates, moves, or deletes rows. |
+| Shopify import creates listings explicitly | Good | Import emits `create_listing` updates instead of relying on inventory side effects. |
+| Listing approval creation | Good | Approval still materializes the approved listing. |
+| Inventory/cost/order/accounting | Good | No movement. |
+| `Default` regressions | Good | Count is 0. |
+| Generated local listing cleanup | Needs review | 362 local listing rows are removed. This is expected directionally but broad. |
+| Love & Fur handle inconsistency | Needs decision | The stricter model exposes a real mismatch between item handles, local listing approval state, and Shopify catalog state. |
+
+## Proposed Next Step
+
+Review the removed generated listing set and decide whether the broad cleanup
+is acceptable. If it is, handle the Love & Fur case as an explicit
+reconciliation problem rather than restoring inventory-driven listing creation.

--- a/docs/investigations/LOVE_FUR_LISTING_HANDLE_MISMATCH_JUN_27_2026.md
+++ b/docs/investigations/LOVE_FUR_LISTING_HANDLE_MISMATCH_JUN_27_2026.md
@@ -1,0 +1,189 @@
+# Love & Fur Sticky Notes Listing Mismatch -- Jun 27 2026
+
+## Scope
+
+This investigation traces the listing mismatch for the Love & Fur sticky
+notes product:
+
+- JAN: `4969757171813`
+- Variants: `Pomeranian`, `Poodle`, `Schnauzer`, `Shiba`
+- Shopify handle currently in the catalog mirror:
+  `kyowa-kawaii-puppy-dog-love-fur-sticky-notes-77`
+
+Source data:
+
+- Broadcast replay backup:
+  `../production-backup-jun-26-trace-4542804151626/firestore-export.json`
+- Branch blast-radius snapshots:
+  `.blastradius/runs/no-inventory-listing-creation-jun27-v3/`
+
+No production data was modified during this investigation.
+
+## Summary
+
+The mismatch is real historical data, not only a current UI display issue.
+
+The listing started as one intended four-variant listing, but the proposal's
+handle was manually set to a free-form, non-Shopify-safe value:
+
+`Kyowa Kawaii Puppy Dog Love & Fur Sticky Notes (75)`
+
+That value was then synced to Shopify multiple times. Shopify did not preserve
+that exact handle; it slugged and de-duplicated it, yielding a sequence of
+Shopify handles:
+
+- `kyowa-kawaii-puppy-dog-love-fur-sticky-notes-75`
+- `kyowa-kawaii-puppy-dog-love-fur-sticky-notes-76`
+- `kyowa-kawaii-puppy-dog-love-fur-sticky-notes-77`
+
+The active Shopify product that survives in catalog sync is product
+`15830616244606` at handle
+`kyowa-kawaii-puppy-dog-love-fur-sticky-notes-77`.
+
+Admin replay also has a separate local listing path under the generated
+JAN-suffixed handle:
+
+`kyowa-kawaii-puppy-dog-love-fur-sticky-notes-75-4969757171813`
+
+The old listing reducer hid this mismatch by allowing handle edits or inventory
+updates to synthesize local listing rows. The stricter reducer correctly stops
+doing that, which exposes the inconsistency: item rows now point to the Shopify
+handle `...-77`, but local `listings.idToHandle` does not link those items to a
+local listing row at `...-77`.
+
+## Timeline
+
+| Time UTC | Broadcast action | Effect |
+|---|---|---|
+| 2026-03-18 16:42 | `listingCreation/add_proposals` | Created one intended four-variant proposal for JAN `4969757171813`. |
+| 2026-03-18 16:44 | `listingCreation/update_proposal_field` | Operator set `field:"handle"` to the free-form value `Kyowa Kawaii Puppy Dog Love & Fur Sticky Notes (75)`. |
+| 2026-03-18 16:46 | `listingCreation/update_proposal_field` | Title changed to `Dobutsu Love & Fur Dog Mini Sticky Notes (75)`. |
+| 2026-03-18 16:52 | `listingCreation/approve_proposal` | Approved the proposal, creating four inventory variants. In current replay this local listing is keyed as `...75-4969757171813`. |
+| 2026-03-18 16:54 | `shopify_api_log product_update` | Shopify response product `15830609428862`, handle `...sticky-notes-75`. |
+| 2026-03-18 16:55 | `shopify_api_log product_update` | Shopify response product `15830612836734`, handle `...sticky-notes-76`. |
+| 2026-03-18 16:56 | `shopify_api_log product_update` | Shopify response product `15830616244606`, handle `...sticky-notes-77`. |
+| 2026-03-18 20:51 | `update_field(handle -> "")` | Operator cleared the listing handle on the variants. |
+| 2026-03-18 20:52 | `update_field(handle -> ...75-4969757171813)` | Operator set the variants to the generated JAN-suffixed admin handle. |
+| 2026-03-30 onward | `shopifyCatalog/apply_sync_chunk` | Catalog sync consistently reports product `15830616244606` at handle `...sticky-notes-77`. |
+| 2026-06-25 18:40 | `update_field(handle -> ...77)` | Operator moved all four inventory variants from `...75-4969757171813` to `...77`. |
+| 2026-06-25 19:17 | `shopify_api_log product_update` | Sync updated Shopify product `15830616244606` at handle `...77`. |
+| 2026-06-25 19:18 onward | `shopifyCatalog/apply_sync_chunk` | Catalog mirror confirms handle `...77`, title `Kyowa Love & Fur Dog Mini Sticky Notes (75)`, active product. |
+
+## Proposal Payload
+
+The original proposal was structurally correct as a four-variant listing:
+
+| Variant | Photo group |
+|---|---|
+| `Pomeranian` | `4969757171813:Pomeranian` |
+| `Poodle` | `4969757171813:Poodle` |
+| `Schnauzer` | `4969757171813:Schnauzer` |
+| `Shiba` | `4969757171813:Shiba` |
+
+The bad field was the handle. The proposal used a human-readable title-like
+string as the handle, rather than a Shopify slug.
+
+## Shopify Evidence
+
+The product update logs show three distinct Shopify product responses for the
+same free-form handle sync sequence:
+
+| Time UTC | Product ID | Shopify response handle |
+|---|---:|---|
+| 2026-03-18 16:54 | `15830609428862` | `kyowa-kawaii-puppy-dog-love-fur-sticky-notes-75` |
+| 2026-03-18 16:55 | `15830612836734` | `kyowa-kawaii-puppy-dog-love-fur-sticky-notes-76` |
+| 2026-03-18 16:56 | `15830616244606` | `kyowa-kawaii-puppy-dog-love-fur-sticky-notes-77` |
+
+Later catalog syncs only report the `...-77` product for this JAN:
+
+| Catalog sync date | Handle | Product ID | Variant SKUs |
+|---|---|---:|---|
+| 2026-03-30 | `...sticky-notes-77` | `15830616244606` | all four `4969757171813...` SKUs |
+| 2026-05-03 | `...sticky-notes-77` | `15830616244606` | all four `4969757171813...` SKUs |
+| 2026-05-18 | `...sticky-notes-77` | `15830616244606` | all four `4969757171813...` SKUs |
+| 2026-06-01 | `...sticky-notes-77` | `15830616244606` | all four `4969757171813...` SKUs |
+| 2026-06-20 | `...sticky-notes-77` | `15830616244606` | all four `4969757171813...` SKUs |
+| 2026-06-25 | `...sticky-notes-77` | `15830616244606` | all four `4969757171813...` SKUs |
+| 2026-06-26 | `...sticky-notes-77` | `15830616244606` | all four `4969757171813...` SKUs |
+
+I did not find catalog mirror evidence that `...-75` or `...-76` survive as
+active catalog products in the replayed backup. They appear in API responses
+during the initial bad-handle sync sequence.
+
+## Materialized State Under Current Branch
+
+After replaying the Jun 26 backup through the current stricter reducer:
+
+Inventory rows:
+
+| Item key | `item.handle` | Qty | Shipped |
+|---|---|---:|---:|
+| `4969757171813Pomeranian` | `...sticky-notes-77` | 12 | 1 |
+| `4969757171813Poodle` | `...sticky-notes-77` | 12 | 2 |
+| `4969757171813Schnauzer` | `...sticky-notes-77` | 12 | 4 |
+| `4969757171813Shiba` | `...sticky-notes-77` | 12 | 1 |
+
+Local listing state:
+
+- `listings.handleToListing["...sticky-notes-77"]`: absent
+- `listings.idToHandle[4969757171813...]`: absent for all four variants
+- `listings.handleToListing["...75-4969757171813"]`: present
+
+Shopify catalog mirror:
+
+- `shopifyCatalog.handleToListing["...sticky-notes-77"]`: present
+- Product ID: `15830616244606`
+- Title: `Kyowa Love & Fur Dog Mini Sticky Notes (75)`
+- Variants: all four `4969757171813...` SKUs
+- Latest observed catalog `updatedAtIso`: `2026-06-26T07:19:30Z`
+
+## Why This Became Visible Now
+
+The branch intentionally enforces this rule:
+
+> Inventory updates and handle edits must not create or delete listing rows.
+
+That is the right direction. It prevents incidental inventory metadata changes
+from silently manufacturing listing state.
+
+However, this Love & Fur case relied on exactly that old behavior. The local
+admin listing row for `...sticky-notes-77` was not created by an explicit
+listing action in the historical log. It appeared because the old reducer was
+willing to synthesize listing rows when item handles changed.
+
+Once that behavior is removed, replay exposes the true mismatch:
+
+- Shopify and item metadata say `...sticky-notes-77`.
+- Local listing approval history says `...75-4969757171813`.
+- No explicit action reconciles the two local listing identities.
+
+## Interpretation
+
+The operator intent appears to have been:
+
+1. Create one four-variant Love & Fur sticky notes listing.
+2. Publish/sync it to Shopify.
+3. Later align admin item handles with the Shopify product handle that actually
+   exists, `...sticky-notes-77`.
+
+The system did not have a clean explicit action for "link/re-key this local
+listing to the Shopify handle." Instead, the old reducer produced that outcome
+as a side effect of handle edits.
+
+## Recommended Fix Direction
+
+Do not restore listing creation from `update_item`, `bulk_import_items`, or
+`update_field(handle)`.
+
+This case needs an explicit reconciliation path. Reasonable options:
+
+1. Add an operator action that re-keys or links an existing local listing to a
+   known Shopify catalog handle.
+2. Make Shopify import/catalog reconciliation capable of explicitly creating or
+   linking local listing rows from known Shopify products, rather than relying
+   on inventory handle side effects.
+3. Add a targeted data remediation for this listing once the intended general
+   action exists.
+
+The important constraint is that the action should be explicit and auditable.
+The reducer should not infer listing creation from an item handle edit.

--- a/e2e/015-listings-creation/variant-updates.spec.ts
+++ b/e2e/015-listings-creation/variant-updates.spec.ts
@@ -227,6 +227,12 @@ test.describe("Variant Updates (Modal-driven)", () => {
       ({ janCode, item1Id, handle }) => {
         const { store, actions } = (window as any).testHelpers;
         store.dispatch(
+          actions.create_listing({
+            handle,
+            listing: { handle, title: "Live Split Test", images: [] },
+          }),
+        );
+        store.dispatch(
           actions.bulk_import_items({
             items: [
               {
@@ -235,12 +241,6 @@ test.describe("Variant Updates (Modal-driven)", () => {
                 type: "new",
               },
             ],
-          }),
-        );
-        store.dispatch(
-          actions.create_listing({
-            handle,
-            listing: { handle, title: "Live Split Test", images: [] },
           }),
         );
       },
@@ -312,6 +312,12 @@ test.describe("Variant Updates (Modal-driven)", () => {
       ({ janCode, keepId, errId, handle }) => {
         const { store, actions } = (window as any).testHelpers;
         store.dispatch(
+          actions.create_listing({
+            handle,
+            listing: { handle, title: "Live Remove Test", images: [] },
+          }),
+        );
+        store.dispatch(
           actions.bulk_import_items({
             items: [
               {
@@ -325,12 +331,6 @@ test.describe("Variant Updates (Modal-driven)", () => {
                 type: "new",
               },
             ],
-          }),
-        );
-        store.dispatch(
-          actions.create_listing({
-            handle,
-            listing: { handle, title: "Live Remove Test", images: [] },
           }),
         );
       },

--- a/e2e/helpers/loading-helper.ts
+++ b/e2e/helpers/loading-helper.ts
@@ -14,12 +14,8 @@ export async function waitForAppReady(page: Page) {
   // Some CI runs can briefly re-attach the overlay after auth/store hydration.
   // Require stable absence before moving on to screenshot capture.
   for (let i = 0; i < 5; i += 1) {
-    await expect(loadingOverlay).toHaveCount(0, { timeout: 5000 });
-    await page.waitForFunction(
-      () => !document.querySelector(".loading-overlay"),
-      undefined,
-      { timeout: 4000 },
-    );
+    await loadingOverlay.waitFor({ state: "detached", timeout: 5000 });
+    await page.waitForTimeout(100);
   }
   console.log("   ✓ Application ready (loading screen removed)");
 }

--- a/scripts/capture-staging-broadcast-after-cutoff.mjs
+++ b/scripts/capture-staging-broadcast-after-cutoff.mjs
@@ -1,55 +1,344 @@
 /**
- * Capture (back up) every staging broadcast doc whose timestamp is AFTER the
- * production-backup cutoff, so they can be deleted to reset staging to the
- * backup state. Writes a file in the shape delete-staging-broadcast-from-backup
- * expects: { cutoff, collections.broadcast.documents:[{id,data}] }.
+ * Capture broadcast docs whose timestamp is after a cutoff.
+ *
+ * The original use was staging-only cleanup after a fixed production backup
+ * cutoff. The script is now parameterized so it can also capture a production
+ * tail after the latest local backup and optionally write a combined replay
+ * export.
  *
  * Usage:
+ *   node scripts/capture-staging-broadcast-after-cutoff.mjs \
+ *     --firestore-env production \
+ *     --backup /tmp/production-backup-jun26-plus-tail \
+ *     --out /tmp/prod-tail.json \
+ *     --combined-output /tmp/prod-plus-tail/firestore-export.json
+ *
+ * Backward-compatible staging default:
  *   node scripts/capture-staging-broadcast-after-cutoff.mjs [out.json]
  */
-import { initializeApp, cert } from "firebase-admin/app";
+import { cert, initializeApp } from "firebase-admin/app";
 import { getFirestore, Timestamp } from "firebase-admin/firestore";
-import { readFileSync, writeFileSync, existsSync } from "fs";
-import { resolve } from "path";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { dirname, resolve } from "path";
 
-// Cutoff = max timestamp in ../production-backup-jun-11 (the backup's last doc:
-// shopify_order_reconciled:13392027353470:2026-06-11T17:04:05+03:00).
-const CUTOFF_SECONDS = 1781186781;
-const CUTOFF_NANOS = 164000000;
-const cutoff = new Timestamp(CUTOFF_SECONDS, CUTOFF_NANOS);
-const outPath = process.argv[2] || "staging-after-cutoff-backup.json";
+const LEGACY_CUTOFF_SECONDS = 1781186781;
+const LEGACY_CUTOFF_NANOS = 164000000;
 
-const keyPath = resolve(process.cwd(), "service-account-staging.json");
-if (!existsSync(keyPath)) {
-  console.error(`Service account key not found: ${keyPath}`);
-  process.exit(1);
+function parseArgs(argv) {
+  const args = {};
+  const positionals = [];
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (!token.startsWith("--")) {
+      positionals.push(token);
+      continue;
+    }
+    const key = token.slice(2);
+    const next = argv[i + 1];
+    if (!next || next.startsWith("--")) {
+      args[key] = true;
+    } else {
+      args[key] = next;
+      i += 1;
+    }
+  }
+  if (positionals[0] && !args.out) args.out = positionals[0];
+  return args;
 }
-const db = getFirestore(
-  initializeApp(
+
+function usage() {
+  console.log(`Capture broadcast docs after a cutoff.
+
+Options:
+  --firestore-env <env>       staging | production | emulator (default: staging)
+  --backup <path>             Backup directory or firestore-export.json; cutoff is max broadcast timestamp
+  --timestamp <value>         Explicit cutoff: ISO string, millis, or seconds.nanoseconds
+  --out <path>                Tail output JSON (default: staging-after-cutoff-backup.json)
+  --combined-output <path>    Optional combined backup + tail firestore-export.json
+  --help                      Show this help
+
+Examples:
+  node scripts/capture-staging-broadcast-after-cutoff.mjs --firestore-env production \\
+    --backup /tmp/production-backup-jun26-plus-tail --out /tmp/prod-tail.json
+
+  node scripts/capture-staging-broadcast-after-cutoff.mjs --firestore-env production \\
+    --backup /tmp/production-backup-jun26-plus-tail \\
+    --combined-output /tmp/production-backup-jun26-plus-latest/firestore-export.json
+`);
+}
+
+function backupFilePath(path) {
+  const resolved = resolve(process.cwd(), path);
+  if (resolved.endsWith(".json")) return resolved;
+  return resolve(resolved, "firestore-export.json");
+}
+
+function normalizeTimestamp(value) {
+  if (!value) return null;
+  if (value instanceof Timestamp) {
+    return { seconds: value.seconds, nanoseconds: value.nanoseconds };
+  }
+  if (value._timestamp === true && typeof value._seconds === "number") {
+    return {
+      seconds: value._seconds,
+      nanoseconds: Number(value._nanoseconds) || 0,
+    };
+  }
+  if (typeof value._seconds === "number") {
+    return {
+      seconds: value._seconds,
+      nanoseconds: Number(value._nanoseconds) || 0,
+    };
+  }
+  if (typeof value.seconds === "number") {
+    return {
+      seconds: value.seconds,
+      nanoseconds: Number(value.nanoseconds) || 0,
+    };
+  }
+  return null;
+}
+
+function compareTimestamps(a, b) {
+  if (a.seconds !== b.seconds) return a.seconds - b.seconds;
+  return a.nanoseconds - b.nanoseconds;
+}
+
+function parseExplicitCutoff(value) {
+  if (!value) return null;
+  if (/^\d+\.\d+$/.test(value)) {
+    const [seconds, nanoseconds] = value.split(".");
+    return {
+      seconds: Number(seconds),
+      nanoseconds: Number(nanoseconds.padEnd(9, "0").slice(0, 9)),
+    };
+  }
+  if (/^\d+$/.test(value)) {
+    const millis = Number(value);
+    if (millis > 10_000_000_000) {
+      return {
+        seconds: Math.floor(millis / 1000),
+        nanoseconds: (millis % 1000) * 1_000_000,
+      };
+    }
+    return { seconds: millis, nanoseconds: 0 };
+  }
+  const parsed = Date.parse(value);
+  if (!Number.isNaN(parsed)) {
+    return {
+      seconds: Math.floor(parsed / 1000),
+      nanoseconds: (parsed % 1000) * 1_000_000,
+    };
+  }
+  throw new Error(`Could not parse cutoff timestamp: ${value}`);
+}
+
+function formatTimestamp(timestamp) {
+  return `${timestamp.seconds}.${String(timestamp.nanoseconds).padStart(9, "0")}`;
+}
+
+function timestampToIso(timestamp) {
+  return new Timestamp(timestamp.seconds, timestamp.nanoseconds)
+    .toDate()
+    .toISOString();
+}
+
+function readBackup(path) {
+  const file = backupFilePath(path);
+  if (!existsSync(file)) throw new Error(`Backup not found: ${file}`);
+  const backup = JSON.parse(readFileSync(file, "utf8"));
+  const documents = backup.collections?.broadcast?.documents;
+  if (!Array.isArray(documents)) {
+    throw new Error(`Backup has no collections.broadcast.documents: ${file}`);
+  }
+  return { file, backup, documents };
+}
+
+function cutoffFromBackup(path) {
+  const { file, documents } = readBackup(path);
+  let max = null;
+  let maxDocument = null;
+  for (const document of documents) {
+    const timestamp = normalizeTimestamp(document.data?.timestamp);
+    if (!timestamp) continue;
+    if (!max || compareTimestamps(timestamp, max) > 0) {
+      max = timestamp;
+      maxDocument = document;
+    }
+  }
+  if (!max) throw new Error(`No usable broadcast timestamps in backup: ${file}`);
+  return { cutoff: max, backupFile: file, maxDocument };
+}
+
+function serializeFirestoreData(data) {
+  return JSON.parse(
+    JSON.stringify(data, (_key, value) => {
+      if (value instanceof Timestamp) {
+        return {
+          _timestamp: true,
+          _seconds: value.seconds,
+          _nanoseconds: value.nanoseconds,
+        };
+      }
+      if (value && typeof value === "object" && "_seconds" in value) {
+        return {
+          _timestamp: true,
+          _seconds: value._seconds,
+          _nanoseconds: value._nanoseconds || 0,
+        };
+      }
+      return value;
+    }),
+  );
+}
+
+function sortBroadcastDocuments(documents) {
+  return [...documents].sort((a, b) => {
+    const aTs = normalizeTimestamp(a.data?.timestamp);
+    const bTs = normalizeTimestamp(b.data?.timestamp);
+    if (aTs && bTs) {
+      const comparison = compareTimestamps(aTs, bTs);
+      if (comparison !== 0) return comparison;
+    } else if (aTs) {
+      return -1;
+    } else if (bTs) {
+      return 1;
+    }
+    return String(a.id).localeCompare(String(b.id));
+  });
+}
+
+async function initFirestore(firestoreEnv) {
+  if (firestoreEnv === "emulator") {
+    process.env.FIRESTORE_EMULATOR_HOST =
+      process.env.FIRESTORE_EMULATOR_HOST || "127.0.0.1:8080";
+    const app = initializeApp(
+      { projectId: process.env.FIREBASE_PROJECT_ID || "demo-test-project" },
+      `capture-broadcast-${firestoreEnv}-${Date.now()}`,
+    );
+    return getFirestore(app);
+  }
+
+  if (!["staging", "production"].includes(firestoreEnv)) {
+    throw new Error(
+      `Invalid --firestore-env ${firestoreEnv}; expected staging, production, or emulator`,
+    );
+  }
+
+  const keyPath = resolve(
+    process.cwd(),
+    `service-account-${firestoreEnv}.json`,
+  );
+  if (!existsSync(keyPath)) {
+    throw new Error(`Service account key not found: ${keyPath}`);
+  }
+  const app = initializeApp(
     { credential: cert(JSON.parse(readFileSync(keyPath, "utf8"))) },
-    "capture-staging-broadcast",
-  ),
+    `capture-broadcast-${firestoreEnv}-${Date.now()}`,
+  );
+  return getFirestore(app);
+}
+
+const args = parseArgs(process.argv.slice(2));
+if (args.help) {
+  usage();
+  process.exit(0);
+}
+
+const firestoreEnv = String(args["firestore-env"] || "staging");
+const outPath = resolve(
+  process.cwd(),
+  String(args.out || "staging-after-cutoff-backup.json"),
 );
+
+let cutoff;
+let cutoffSource = "legacy";
+let backupInfo = null;
+
+if (args.backup) {
+  backupInfo = cutoffFromBackup(String(args.backup));
+  cutoff = backupInfo.cutoff;
+  cutoffSource = backupInfo.backupFile;
+} else if (args.timestamp) {
+  cutoff = parseExplicitCutoff(String(args.timestamp));
+  cutoffSource = "--timestamp";
+} else {
+  cutoff = {
+    seconds: LEGACY_CUTOFF_SECONDS,
+    nanoseconds: LEGACY_CUTOFF_NANOS,
+  };
+}
+
+const cutoffTimestamp = new Timestamp(cutoff.seconds, cutoff.nanoseconds);
+const db = await initFirestore(firestoreEnv);
 
 const total = (await db.collection("broadcast").count().get()).data().count;
 const snap = await db
   .collection("broadcast")
-  .where("timestamp", ">", cutoff)
+  .where("timestamp", ">", cutoffTimestamp)
+  .orderBy("timestamp", "asc")
   .get();
 
 const documents = [];
-snap.forEach((doc) => documents.push({ id: doc.id, data: doc.data() }));
+snap.forEach((doc) =>
+  documents.push({ id: doc.id, data: serializeFirestoreData(doc.data()) }),
+);
 
 const out = {
   capturedAt: new Date().toISOString(),
-  cutoff: { _seconds: CUTOFF_SECONDS, _nanoseconds: CUTOFF_NANOS },
+  firestoreEnv,
+  cutoffSource,
+  cutoff: {
+    _seconds: cutoff.seconds,
+    _nanoseconds: cutoff.nanoseconds,
+  },
   collections: { broadcast: { documents } },
 };
+
+mkdirSync(dirname(outPath), { recursive: true });
 writeFileSync(outPath, JSON.stringify(out, null, 2));
 
-console.log(`Cutoff: ${cutoff.toDate().toISOString()}`);
-console.log(`Staging broadcast total: ${total}`);
+let combinedPath = null;
+if (args["combined-output"]) {
+  if (!args.backup) {
+    throw new Error("--combined-output requires --backup");
+  }
+  const { backup } = readBackup(String(args.backup));
+  const existingById = new Map(
+    backup.collections.broadcast.documents.map((document) => [
+      document.id,
+      document,
+    ]),
+  );
+  for (const document of documents) existingById.set(document.id, document);
+  backup.collections.broadcast.documents = sortBroadcastDocuments(
+    Array.from(existingById.values()),
+  );
+  backup.exportedAt = new Date().toISOString();
+  backup.tailCapture = {
+    capturedAt: out.capturedAt,
+    firestoreEnv,
+    cutoffSource,
+    cutoff: out.cutoff,
+    tailDocumentCount: documents.length,
+  };
+
+  combinedPath = resolve(process.cwd(), String(args["combined-output"]));
+  mkdirSync(dirname(combinedPath), { recursive: true });
+  writeFileSync(combinedPath, JSON.stringify(backup, null, 2));
+}
+
+console.log(`Environment: ${firestoreEnv}`);
+console.log(`Cutoff source: ${cutoffSource}`);
+console.log(`Cutoff: ${timestampToIso(cutoff)} (${formatTimestamp(cutoff)})`);
+if (backupInfo?.maxDocument) {
+  console.log(
+    `Backup max doc: ${backupInfo.maxDocument.id} ${backupInfo.maxDocument.data?.type || ""}`,
+  );
+}
+console.log(`Broadcast total in ${firestoreEnv}: ${total}`);
 console.log(`After-cutoff docs captured: ${documents.length}`);
-console.log(`Expected staging total after delete: ${total - documents.length}`);
-console.log(`Wrote ${outPath}`);
+console.log(`Expected total before cutoff/in backup: ${total - documents.length}`);
+console.log(`Wrote tail: ${outPath}`);
+if (combinedPath) console.log(`Wrote combined export: ${combinedPath}`);
 process.exit(0);

--- a/src/lib/inventory.ts
+++ b/src/lib/inventory.ts
@@ -3474,7 +3474,7 @@ function resolveLabeledSkuToSingleCurrentBareJan(
   };
 }
 
-function resolveCurrentInventoryKeyForNonSubtypeMutation(
+function resolveCurrentInventoryKeyForMutation(
   state: InventoryState,
   rawItemKey: string,
 ): InventoryItemKey {
@@ -3484,6 +3484,20 @@ function resolveCurrentInventoryKeyForNonSubtypeMutation(
     resolveLabeledSkuToSingleCurrentBareJan(state, rawItemKey)?.itemKey ||
     itemKey
   );
+}
+
+export function resolveCurrentInventoryKeyForSubtypeMutation(
+  state: InventoryState,
+  rawItemKey: string,
+): InventoryItemKey {
+  return resolveCurrentInventoryKeyForMutation(state, rawItemKey);
+}
+
+function resolveCurrentInventoryKeyForNonSubtypeMutation(
+  state: InventoryState,
+  rawItemKey: string,
+): InventoryItemKey {
+  return resolveCurrentInventoryKeyForMutation(state, rawItemKey);
 }
 
 function resolveLineItemInventoryKey(
@@ -4964,7 +4978,7 @@ export const inventory = createReducer(initialState, (r) => {
     const { field, to: incomingValue, from } = action.payload;
     const itemKey =
       field === "subtype"
-        ? canonicalizeInventoryItemKey(action.payload.id)
+        ? resolveCurrentInventoryKeyForSubtypeMutation(state, action.payload.id)
         : resolveCurrentInventoryKeyForNonSubtypeMutation(
             state,
             action.payload.id,
@@ -5159,7 +5173,7 @@ export const inventory = createReducer(initialState, (r) => {
       ({ field }) => field === "subtype",
     );
     const itemKey = hasSubtypeField
-      ? canonicalizeInventoryItemKey(action.payload.id)
+      ? resolveCurrentInventoryKeyForSubtypeMutation(state, action.payload.id)
       : resolveCurrentInventoryKeyForNonSubtypeMutation(
           state,
           action.payload.id,

--- a/src/lib/listings-slice.ts
+++ b/src/lib/listings-slice.ts
@@ -149,7 +149,9 @@ export const listings = createReducer(initialState, (builder) => {
         }
       }),
     )
-    // Legacy Action Handling for Replay
+    // Inventory actions may update or link existing listings, but they must
+    // not synthesize listing rows. Listing rows are created by Shopify import,
+    // explicit listing actions, or listing draft approval.
     .addCase(
       update_item,
       withTimestamp((state, action) => {
@@ -164,10 +166,7 @@ export const listings = createReducer(initialState, (builder) => {
     .addCase(
       bulk_import_items,
       withTimestamp((state, action) => {
-        // Iterate over all items in the bulk import and process them
         for (const importItem of action.payload.items) {
-          // We treat 'new' and 'update' similarly for listings:
-          // ensure listing exists and update fields if present.
           handleLegacyUpdate(
             state,
             importItem.id,
@@ -216,96 +215,51 @@ export const listings = createReducer(initialState, (builder) => {
     );
 });
 
-// Helper to consolidate logic between update_item and bulk_import_items
+// Helper to consolidate existing-listing updates between update_item and
+// bulk_import_items. This intentionally never creates handleToListing rows.
 function handleLegacyUpdate(
   state: ListingsState,
   id: string,
   itemPayload: any,
   timestampMs: number,
 ) {
-  // 1. Resolve Handle
   let handle = state.idToHandle[id];
+  const explicitHandle = String(itemPayload.handle || "").trim();
 
-  // If no handle mapped, try to generate from payload (Creation scenario)
-  if (!handle) {
-    if (itemPayload.handle) handle = itemPayload.handle;
-    else if (itemPayload.description && itemPayload.janCode) {
-      handle = generateHandle(itemPayload.description, itemPayload.janCode);
-    } else {
-      if (!itemPayload.janCode) return;
-      handle = generateHandle(
-        itemPayload.description || "Untitled",
-        itemPayload.janCode,
-      );
-    }
+  if (handle && !state.handleToListing[handle]) {
+    delete state.idToHandle[id];
+    handle = "";
+  }
+
+  if (!handle && explicitHandle && state.handleToListing[explicitHandle]) {
+    handle = explicitHandle;
     state.idToHandle[id] = handle;
   }
 
-  // 2. Get Existing Listing or Create New
-  let listing = state.handleToListing[handle];
-
-  if (!listing) {
-    // Creation Scenario
-    listing = {
-      handle,
-      title: itemPayload.description || "Untitled",
-      bodyHtml: itemPayload.bodyHtml || "",
-      productCategory: itemPayload.productCategory || "",
-      productType: "",
-      vendor: "SPNSS Ltd.",
-      tags: [],
-      status: "active",
-      option1Name: "Subtype",
-      images: [],
-      lastUpdated: timestampMs,
-      // Store janCode for future re-generation/validation if needed?
-      // Not strictly in Listing interface but useful.
-      // We rely on idToHandle map + payload updates.
-    } as Listing; // Cast to force verify or allow extra props if needed
-
-    // Inject janCode property directly if flexible, or rely only on payload
-    (listing as any).janCode = itemPayload.janCode;
-
-    if (listing.productCategory) ensureCategory(state, listing.productCategory);
-    state.handleToListing[handle] = listing;
+  if (!handle && itemPayload.description && itemPayload.janCode) {
+    const generatedHandle = generateHandle(
+      itemPayload.description,
+      itemPayload.janCode,
+    );
+    if (state.handleToListing[generatedHandle]) {
+      handle = generatedHandle;
+      state.idToHandle[id] = handle;
+    }
   }
 
-  // 3. Handle Updates & Renames
-  const currentJanCode = (listing as any).janCode || itemPayload.janCode;
+  if (!handle) return;
+
+  let listing = state.handleToListing[handle];
+  if (!listing) return;
+
   if (itemPayload.janCode) (listing as any).janCode = itemPayload.janCode;
 
-  // Check if payload provides an explicit handle (e.g. from Shopify Import)
-  // or if we need to regenerate due to title/jan change.
   let targetHandle = handle;
   let newTitle = itemPayload.description || listing.title;
 
-  if (itemPayload.handle) {
-    targetHandle = itemPayload.handle;
+  if (explicitHandle) {
+    targetHandle = explicitHandle;
   }
-  // REVISED (2025-12-22):
-  // Do NOT regenerate handle implicitly on title/jan change.
-  // Handles should be sticky (like Shopify). Only update if explicit handle provided.
-  // This preserves custom handles (e.g. from bulk import) even if legacy update_item actions come in.
-
-  /*
-      else if (itemPayload.description || itemPayload.janCode) {
-           const newTitle = itemPayload.description || listing.title;
-           const newJan = itemPayload.janCode || (listing as any).janCode;
-           
-           // Only regenerate handle if the data actually changed.
-           // This prevents legacy update_item actions (merged from inventory) from
-           // clobbering a custom handle set by bulk_import_items if the description is the same.
-           const titleChanged = itemPayload.description && itemPayload.description !== listing.title;
-           const janChanged = itemPayload.janCode && itemPayload.janCode !== (listing as any).janCode;
-
-           if ((titleChanged || janChanged) && newJan) {
-               if (newTitle.toLowerCase().includes('zebra')) {
-                   console.log(`[Slice Debug] Regenerating handle for ${newTitle}. Old: ${handle}. TitleChanged: ${titleChanged} ('${listing.title}' vs '${itemPayload.description}'). JanChanged: ${janChanged}`);
-               }
-               targetHandle = generateHandle(newTitle, newJan);
-           }
-      }
-      */
 
   if (targetHandle !== handle) {
     applyHandleUpdate(state, id, targetHandle, handle, timestampMs);
@@ -368,67 +322,29 @@ function applyHandleUpdate(
   const priorListing = priorHandle
     ? state.handleToListing[priorHandle]
     : undefined;
-  const defaultHandle =
-    !newHandle && priorListing
-      ? generateHandle(
-          priorListing.title,
-          (priorListing as any).janCode ||
-            String(id).match(/^\d{8,14}/)?.[0] ||
-            "",
-        )
-      : "";
-  const targetHandle = newHandle || defaultHandle;
+  const targetHandle = newHandle;
+  const targetListing = targetHandle
+    ? state.handleToListing[targetHandle]
+    : undefined;
   if (priorHandle === targetHandle) return;
+  const priorOption = priorListing?.variantOptionsByItemId?.[id];
 
-  if (targetHandle) {
+  if (targetHandle && targetListing) {
     state.idToHandle[id] = targetHandle;
   } else {
     delete state.idToHandle[id];
   }
 
-  if (!priorHandle) return;
-
-  // Check if priorHandle is still in use by ANY other ID
-  const isStillUsed = Object.values(state.idToHandle).includes(priorHandle);
-  if (!targetHandle) {
-    // Un-listing logic: if no one else uses the old handle and no default
-    // handle can be generated, delete the listing.
-    if (!isStillUsed && priorListing) {
-      delete state.handleToListing[priorHandle];
-    }
-    return;
-  }
-
-  // Move/Split logic (only if targetHandle is truthy)
-  const targetListing = state.handleToListing[targetHandle];
-
-  if (priorListing && !targetListing) {
-    if (!isStillUsed) {
-      // Move (Rename) - No one else uses old handle, so we move the listing entity
-      const movedListing = {
-        ...priorListing,
-        handle: targetHandle,
-        lastUpdated: keepLatestTimestamp(priorListing.lastUpdated, timestampMs),
+  if (targetListing && priorListing !== targetListing) {
+    if (priorOption) {
+      targetListing.variantOptionsByItemId = {
+        ...(targetListing.variantOptionsByItemId || {}),
+        [id]: priorOption,
       };
-      delete state.handleToListing[priorHandle];
-      state.handleToListing[targetHandle] = movedListing;
-    } else {
-      // Split (Clone) - Old handle still used, so we create a NEW listing for this item, cloning context
-      const newListing = {
-        ...priorListing,
-        handle: targetHandle,
-        lastUpdated: keepLatestTimestamp(priorListing.lastUpdated, timestampMs),
-      };
-      state.handleToListing[targetHandle] = newListing;
-    }
-    return;
-  }
-
-  if (priorListing && targetListing) {
-    // Merge into existing target
-    if (!isStillUsed) {
-      // Old handle empty, cleanup
-      delete state.handleToListing[priorHandle];
+      targetListing.lastUpdated = keepLatestTimestamp(
+        targetListing.lastUpdated,
+        timestampMs,
+      );
     }
   }
 }

--- a/src/lib/listings-slice.ts
+++ b/src/lib/listings-slice.ts
@@ -71,6 +71,10 @@ export const update_listing = createAction<{
   handle: string;
   changes: Partial<Listing>;
 }>("update_listing");
+export const rename_listing_handle = createAction<{
+  from: string;
+  to: string;
+}>("rename_listing_handle");
 export const delete_listing = createAction<{ handle: string }>(
   "delete_listing",
 );
@@ -107,6 +111,34 @@ export const listings = createReducer(initialState, (builder) => {
           };
           if (changes.productCategory)
             ensureCategory(state, changes.productCategory);
+        }
+      }),
+    )
+    .addCase(
+      rename_listing_handle,
+      withTimestamp((state, action) => {
+        const from = String(action.payload.from || "").trim();
+        const to = String(action.payload.to || "").trim();
+        if (!from || !to || from === to) return;
+
+        const existing = state.handleToListing[from];
+        if (!existing) return;
+
+        // A handle rename should not implicitly merge or overwrite listings.
+        if (state.handleToListing[to]) return;
+
+        delete state.handleToListing[from];
+        state.handleToListing[to] = {
+          ...existing,
+          handle: to,
+          lastUpdated: keepLatestTimestamp(
+            existing.lastUpdated,
+            actionTimestampMs(action),
+          ),
+        };
+
+        for (const [id, handle] of Object.entries(state.idToHandle)) {
+          if (handle === from) state.idToHandle[id] = to;
         }
       }),
     )

--- a/src/lib/listings-slice.ts
+++ b/src/lib/listings-slice.ts
@@ -25,7 +25,7 @@ export interface Listing {
   productType: string;
   vendor: string;
   tags: string[];
-  status: "active" | "archived" | "draft";
+  status: "active" | "archived" | "draft" | "no_sync";
   option1Name: string; // e.g., "Color" or "Style"
   variantOptionsByItemId?: Record<string, string>;
   images: ListingImage[];

--- a/src/lib/root-reducer.ts
+++ b/src/lib/root-reducer.ts
@@ -658,6 +658,28 @@ const toNonDeletedShopifyPathVariant = memoizeStringFn(
   },
 );
 
+const stableHash = (value: string): string => {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(36);
+};
+
+const makeStableSyntheticPhotoId = (
+  photoKey: string,
+  imageUrl: string,
+): string =>
+  `synthetic-${stableHash(
+    `${photoKey}\n${canonicalizeShopifyCdnUrl(imageUrl)}`,
+  )}`;
+
+const syntheticPhotoCreationTime = (timestampMs: number): string =>
+  timestampMs > 0
+    ? new Date(timestampMs).toISOString()
+    : "1970-01-01T00:00:00.000Z";
+
 // Root reducer to handle full state hydration and Event Sourcing Orchestration
 export const rootReducer = (
   state: any,
@@ -1928,13 +1950,13 @@ export const rootReducer = (
             nextJanCodeToPhotos[photoKey] = [];
 
           const syntheticPhoto = {
-            id: `synthetic-${crypto.randomUUID()}`,
+            id: makeStableSyntheticPhotoId(photoKey, item.image),
             baseUrl: item.image,
             productUrl: item.image,
             mimeType: "image/jpeg",
             filename: "imported.jpg",
             mediaMetadata: {
-              creationTime: new Date().toISOString(),
+              creationTime: syntheticPhotoCreationTime(action._timestamp),
               width: "0",
               height: "0",
             },

--- a/src/lib/root-reducer.ts
+++ b/src/lib/root-reducer.ts
@@ -103,6 +103,17 @@ function nonDefaultOptionLabel(value: unknown): string {
   const option = String(value || "").trim();
   return canonicalizeSubtype(option) ? option : "";
 }
+
+function optionLabelMatchesSubtype(
+  optionLabel: string,
+  subtypeLabel: string,
+): boolean {
+  return (
+    !!optionLabel &&
+    !!subtypeLabel &&
+    optionLabel.trim().toLowerCase() === subtypeLabel.trim().toLowerCase()
+  );
+}
 const combinedReducer = combineReducers(reducerObject);
 
 export { toTimestampMs };
@@ -150,14 +161,18 @@ const migrateListingItemReference = (
     const newOption = nonDefaultOptionLabel(currentOptions[newItemId]);
     const fallbackOption = nonDefaultOptionLabel(fallbackOptionLabel);
     const oldSubtypeOption = nonDefaultOptionLabel(oldSubtypeLabel);
-    const oldOptionWasSubtype =
-      oldOption &&
-      oldSubtypeOption &&
-      oldOption.trim().toLowerCase() === oldSubtypeOption.trim().toLowerCase();
+    const oldOptionWasSubtype = optionLabelMatchesSubtype(
+      oldOption,
+      oldSubtypeOption,
+    );
+    const newOptionWasOldSubtype = optionLabelMatchesSubtype(
+      newOption,
+      oldSubtypeOption,
+    );
     const optionLabel =
-      newOption ||
-      (oldOptionWasSubtype ? fallbackOption : oldOption) ||
-      fallbackOption;
+      oldOptionWasSubtype || newOptionWasOldSubtype
+        ? fallbackOption || newOption || oldOption
+        : newOption || oldOption || fallbackOption;
 
     if (optionLabel || oldItemId in currentOptions) {
       const nextOptions = { ...currentOptions };
@@ -854,7 +869,7 @@ export const rootReducer = (
         newSubtype = newItem.subtype;
       }
     } else if (isSubtypeUpdate) {
-      const { id: itemKey, to: subtype } = action.payload;
+      const { id: itemKey, from, to: subtype } = action.payload;
       oldItemId = resolveCurrentInventoryKeyForSubtypeMutation(
         state.inventory,
         itemKey,
@@ -864,7 +879,7 @@ export const rootReducer = (
       if (oldItem) {
         oldBaseJan = oldItem.janCode;
         newBaseJan = oldBaseJan;
-        oldSubtype = oldItem.subtype;
+        oldSubtype = ((from as string) ?? oldItem.subtype ?? "").trim();
         newItemId = makeInventoryItemKey(newBaseJan, newSubtype);
       }
     } else if (isFixJanCode) {

--- a/src/lib/root-reducer.ts
+++ b/src/lib/root-reducer.ts
@@ -13,6 +13,7 @@ import {
   fix_jancode,
   set_stock_order_meta,
   apply_stock_order_costs,
+  resolveCurrentInventoryKeyForSubtypeMutation,
 } from "./inventory";
 import { names } from "./names";
 import { photos, rename_jan_group } from "./photos-slice";
@@ -854,7 +855,10 @@ export const rootReducer = (
       }
     } else if (isSubtypeUpdate) {
       const { id: itemKey, to: subtype } = action.payload;
-      oldItemId = itemKey;
+      oldItemId = resolveCurrentInventoryKeyForSubtypeMutation(
+        state.inventory,
+        itemKey,
+      );
       newSubtype = (subtype as string)?.trim() || "";
       const oldItem = state.inventory.idToItem[oldItemId];
       if (oldItem) {

--- a/src/lib/root-reducer.ts
+++ b/src/lib/root-reducer.ts
@@ -37,6 +37,7 @@ import {
   listings,
   add_listing_image,
   create_listing,
+  rename_listing_handle,
   update_listing,
 } from "./listings-slice";
 import {
@@ -740,6 +741,53 @@ export const rootReducer = (
   }
 
   // 3. Interception & Composition
+
+  if (action.type === rename_listing_handle.type) {
+    const from = String(action.payload?.from || "").trim();
+    const to = String(action.payload?.to || "").trim();
+    const renameApplied =
+      from &&
+      to &&
+      from !== to &&
+      !!state?.listings?.handleToListing?.[from] &&
+      !state?.listings?.handleToListing?.[to] &&
+      !!nextState?.listings?.handleToListing?.[to] &&
+      !nextState?.listings?.handleToListing?.[from];
+    if (renameApplied) {
+      const affectedItemIds = new Set<string>();
+      for (const [id, handle] of Object.entries(
+        state?.listings?.idToHandle || {},
+      )) {
+        if (handle === from) affectedItemIds.add(id);
+      }
+      for (const [id, item] of Object.entries(
+        state?.inventory?.idToItem || {},
+      ) as [string, any][]) {
+        if (item?.handle === from) affectedItemIds.add(id);
+      }
+
+      for (const id of affectedItemIds) {
+        const currentHandle = nextState.inventory?.idToItem?.[id]?.handle || "";
+        if (!nextState.inventory?.idToItem?.[id] || currentHandle === to) {
+          continue;
+        }
+        const syncInventoryHandleAction = inheritTimestamp({
+          ...update_field({
+            id,
+            field: "handle",
+            from: currentHandle,
+            to,
+          }),
+          _ephemeral: true,
+        });
+        nextState = {
+          ...nextState,
+          inventory: inventory(nextState.inventory, syncInventoryHandleAction),
+        };
+        logger(syncInventoryHandleAction, nextState, action._timestamp);
+      }
+    }
+  }
 
   if (
     action.type === replaceShopifySyncEvents.type &&

--- a/src/lib/root-reducer.ts
+++ b/src/lib/root-reducer.ts
@@ -63,6 +63,7 @@ import { buildDraftListingImages } from "./listing-image-logic";
 import {
   canonicalizeInventoryItemKey,
   canonicalizeSubtype,
+  isDefaultSubtype,
   makeInventoryItemKey,
 } from "./sku";
 import { CURRENT_SCHEMA_VERSION } from "./schema-version";
@@ -196,6 +197,61 @@ const migrateListingItemReference = (
       ...listingState,
       idToHandle: nextIdToHandle,
       handleToListing: nextHandleToListing,
+    },
+  };
+};
+
+const itemKeyBelongsToJan = (itemId: string, janCode: string): boolean => {
+  if (!itemId || !janCode || !itemId.startsWith(janCode)) return false;
+  const suffix = itemId.slice(janCode.length);
+  return suffix === "" || !/^\d/.test(suffix);
+};
+
+const clearDefaultListingOptionsForItem = (
+  nextState: any,
+  itemId: string,
+  janCode: string,
+): any => {
+  const listingState = nextState?.listings;
+  const handle = listingState?.idToHandle?.[itemId];
+  const listing = handle ? listingState?.handleToListing?.[handle] : undefined;
+  const currentOptions = listing?.variantOptionsByItemId;
+  if (!listingState || !handle || !listing || !currentOptions) return nextState;
+
+  const linkedSameJanIds = Object.entries(listingState.idToHandle || {})
+    .filter(
+      ([id, linkedHandle]) =>
+        linkedHandle === handle && itemKeyBelongsToJan(id, janCode),
+    )
+    .map(([id]) => id);
+
+  const nextOptions = { ...currentOptions };
+  let changed = false;
+
+  if (linkedSameJanIds.length <= 1) {
+    for (const optionItemId of Object.keys(nextOptions)) {
+      if (itemKeyBelongsToJan(optionItemId, janCode)) {
+        delete nextOptions[optionItemId];
+        changed = true;
+      }
+    }
+  } else if (itemId in nextOptions) {
+    delete nextOptions[itemId];
+    changed = true;
+  }
+
+  if (!changed) return nextState;
+  return {
+    ...nextState,
+    listings: {
+      ...listingState,
+      handleToListing: {
+        ...listingState.handleToListing,
+        [handle]: {
+          ...listing,
+          variantOptionsByItemId: nextOptions,
+        },
+      },
     },
   };
 };
@@ -986,6 +1042,18 @@ export const rootReducer = (
           }
         }
       }
+    } else if (
+      isSubtypeUpdate &&
+      oldItemId &&
+      newItemId &&
+      oldItemId === newItemId &&
+      isDefaultSubtype(newSubtype)
+    ) {
+      nextState = clearDefaultListingOptionsForItem(
+        nextState,
+        oldItemId,
+        newBaseJan || oldBaseJan,
+      );
     }
 
     if (isFixJanCode && oldItemId && newItemId && oldItemId !== newItemId) {

--- a/src/lib/root-reducer.ts
+++ b/src/lib/root-reducer.ts
@@ -200,6 +200,34 @@ const migrateListingItemReference = (
   };
 };
 
+const removeMissingListingHandleReferences = (nextState: any): any => {
+  const listingState = nextState?.listings;
+  const idToHandle = listingState?.idToHandle;
+  const handleToListing = listingState?.handleToListing;
+  if (!idToHandle || !handleToListing) return nextState;
+
+  let changed = false;
+  const nextIdToHandle: Record<string, string> = {};
+  for (const [id, handle] of Object.entries(idToHandle) as Array<
+    [string, string]
+  >) {
+    if (handleToListing[handle]) {
+      nextIdToHandle[id] = handle;
+    } else {
+      changed = true;
+    }
+  }
+
+  if (!changed) return nextState;
+  return {
+    ...nextState,
+    listings: {
+      ...listingState,
+      idToHandle: nextIdToHandle,
+    },
+  };
+};
+
 const getIncomingIdObservations = (
   action: any,
 ): Array<{
@@ -1411,18 +1439,19 @@ export const rootReducer = (
       item: u.type === "new" ? mapShopifyToInventory(u.item) : u.item,
     }));
 
+    let bulkListingsAction: any = null;
     if (bulkUpdates.length > 0) {
-      const internalAction = inheritTimestamp({
+      bulkListingsAction = inheritTimestamp({
         ...bulk_import_items({ items: bulkUpdates }),
         _ephemeral: true,
       });
 
       nextState = {
         ...nextState,
-        inventory: inventory(nextState.inventory, internalAction),
-        listings: listings(nextState.listings, internalAction),
+        inventory: inventory(nextState.inventory, bulkListingsAction),
+        listings: listings(nextState.listings, bulkListingsAction),
       };
-      logger(internalAction, nextState, action._timestamp); // LOG SUB-ACTION
+      logger(bulkListingsAction, nextState, action._timestamp); // LOG SUB-ACTION
       nextState = reconcileImportItemRekeys(
         nextState,
         bulkUpdates,
@@ -1494,6 +1523,13 @@ export const rootReducer = (
       listingUpdates.forEach((u: any) => applyListingUpdate(u));
       deferredVariantOptions.forEach((u: any) => applyListingUpdate(u, false));
       nextState = { ...nextState, listings: nextListings };
+
+      if (bulkListingsAction) {
+        nextState = {
+          ...nextState,
+          listings: listings(nextState.listings, bulkListingsAction),
+        };
+      }
     }
 
     if (indices.length > 0) {
@@ -2366,8 +2402,9 @@ export const rootReducer = (
         }
       });
 
-      // 4.5 Ensure ALL merged items point to the final handle in listings state
-      // (Avoid stale idToHandle entries from previous handles after merges)
+      // 4.5 Ensure ALL merged items point to the final handle in listings state.
+      // Listing approval may create/update the approved listing, but it must
+      // not delete prior listing rows as an incidental handle cleanup.
       const mergedItemIds = new Set<string>();
       allVariants.forEach((v: any) => {
         const currentItemId = variantIdToItemId.get(v.id) || v.itemId;
@@ -2376,22 +2413,9 @@ export const rootReducer = (
       if (mergedItemIds.size > 0) {
         const listingState = nextState.listings;
         const nextIdToHandle = { ...listingState.idToHandle };
-        const nextHandleToListing = { ...listingState.handleToListing };
-        const priorHandles = new Set<string>();
 
         mergedItemIds.forEach((id) => {
-          const prior = nextIdToHandle[id];
-          if (prior && prior !== finalHandle) priorHandles.add(prior);
           nextIdToHandle[id] = finalHandle;
-        });
-
-        // Clean up old handles if no longer used
-        priorHandles.forEach((handle) => {
-          if (handle === finalHandle) return;
-          const stillUsed = Object.values(nextIdToHandle).includes(handle);
-          if (!stillUsed) {
-            delete nextHandleToListing[handle];
-          }
         });
 
         nextState = {
@@ -2399,7 +2423,6 @@ export const rootReducer = (
           listings: {
             ...listingState,
             idToHandle: nextIdToHandle,
-            handleToListing: nextHandleToListing,
           },
         };
       }
@@ -2525,6 +2548,8 @@ export const rootReducer = (
     "listingCreation/start_batch",
     "listingCreation/set_current_step",
   ];
+
+  nextState = removeMissingListingHandleReferences(nextState);
 
   if (criticalActions.includes(action.type)) {
     logger(action, nextState, action._timestamp);

--- a/src/lib/shopify-import-slice.ts
+++ b/src/lib/shopify-import-slice.ts
@@ -282,6 +282,63 @@ export const computeShopifyImportBatch = (
     });
   };
 
+  const ensureListingUpdate = (
+    storeHandle: string,
+    item: ShopifyImportItem | null | undefined,
+  ) => {
+    if (
+      !storeHandle ||
+      handleToListing[storeHandle] ||
+      createdHandles.has(storeHandle)
+    ) {
+      return;
+    }
+    if (!item) return;
+    listingUpdates.push({
+      type: "create_listing",
+      listing: {
+        handle: storeHandle,
+        title: item.description || "Untitled",
+        bodyHtml: item.bodyHtml || "",
+        productCategory: item.productCategory || "",
+        productType: "",
+        vendor: "SPNSS Ltd.",
+        tags: [],
+        status: "active",
+        option1Name: item.option1Name || "Title",
+        images: [],
+        lastUpdated: timestampMs,
+      },
+    });
+    createdHandles.add(storeHandle);
+  };
+
+  const queueListingImageUpdate = (
+    storeHandle: string,
+    item: ShopifyImportItem,
+    targetImage: string | undefined,
+  ) => {
+    if (!storeHandle || !targetImage) return;
+    let alreadyHasImage = false;
+    const listing = handleToListing[storeHandle];
+    if (listing?.images) {
+      alreadyHasImage = listing.images.some(
+        (img: any) => img.url === targetImage,
+      );
+    }
+    if (alreadyHasImage) return;
+    listingUpdates.push({
+      type: "add_image",
+      handle: storeHandle,
+      image: {
+        id: targetImage,
+        url: targetImage,
+        position: item.imagePosition || 0,
+        altText: item.imageAltText || "",
+      },
+    });
+  };
+
   const useDesc = options?.useShopifyDescription ?? false;
   const useImg = options?.useShopifyImages ?? false;
   const useHandles = options?.useShopifyHandles ?? false;
@@ -442,6 +499,7 @@ export const computeShopifyImportBatch = (
           id: key,
           item: newItem,
         });
+        ensureListingUpdate(storeHandle, item);
         queueVariantOptionUpdate(storeHandle, key, item);
       });
 
@@ -449,60 +507,12 @@ export const computeShopifyImportBatch = (
 
       // Add Image to Listing (Gallery) using Store Handle
       if (useImg && storeHandle) {
-        const listingExists =
-          handleToListing[storeHandle] || createdHandles.has(storeHandle);
+        ensureListingUpdate(
+          storeHandle,
+          (parentJan ? janToRow.get(parentJan) : null) || item,
+        );
 
-        // RECOVERY: If listing missing, try to find parent in this batch and create it
-        if (!listingExists) {
-          const parentItem = parentJan ? janToRow.get(parentJan) : null;
-
-          if (parentItem) {
-            listingUpdates.push({
-              type: "create_listing",
-              listing: {
-                handle: storeHandle,
-                title: parentItem.description || "Untitled",
-                bodyHtml: parentItem.bodyHtml || "",
-                productCategory: parentItem.productCategory || "",
-                productType: "",
-                vendor: "SPNSS Ltd.",
-                tags: [],
-                status: "active",
-                option1Name: parentItem.option1Name || "Title",
-                images: [],
-                lastUpdated: timestampMs,
-              },
-            });
-            createdHandles.add(storeHandle);
-          }
-        }
-
-        const targetImage = sanitizedListingImage;
-
-        if (targetImage) {
-          let alreadyHasImage = false;
-          // Listing might be in handleToListing OR just created (not in handleToListing yet)
-          // If created, images is empty.
-          const listing = handleToListing[storeHandle];
-          if (listing && listing.images) {
-            alreadyHasImage = listing.images.some(
-              (img: any) => img.url === targetImage,
-            );
-          }
-
-          if (!alreadyHasImage) {
-            listingUpdates.push({
-              type: "add_image",
-              handle: storeHandle,
-              image: {
-                id: targetImage,
-                url: targetImage,
-                position: item.imagePosition || 0,
-                altText: item.imageAltText || "",
-              },
-            });
-          }
-        }
+        queueListingImageUpdate(storeHandle, item, sanitizedListingImage);
       }
     } else if (filter === "NEW" && !exists) {
       if (item.janCode) {
@@ -517,54 +527,22 @@ export const computeShopifyImportBatch = (
           id: item.janCode,
           item: itemWithoutShopifySubtype,
         });
+        ensureListingUpdate(storeHandle, item);
+        if (useImg && storeHandle) {
+          queueListingImageUpdate(storeHandle, item, sanitizedListingImage);
+        }
         queueVariantOptionUpdate(storeHandle, item.janCode, item);
-        if (storeHandle) createdHandles.add(storeHandle);
         indices.push(index);
       } else if (storeHandle) {
-        const listingExists =
-          handleToListing[storeHandle] || createdHandles.has(storeHandle);
-
-        // RECOVERY: If listing missing, try to find parent in this batch and create it
-        if (!listingExists) {
-          const parentJan = csvHandleToJan.get(item.handle || "");
-          const parentItem = parentJan ? janToRow.get(parentJan) : null;
-
-          if (parentItem) {
-            listingUpdates.push({
-              type: "create_listing",
-              listing: {
-                handle: storeHandle,
-                title: parentItem.description || "Untitled",
-                bodyHtml: parentItem.bodyHtml || "",
-                productCategory: parentItem.productCategory || "",
-                productType: "",
-                vendor: "SPNSS Ltd.",
-                tags: [],
-                status: "active",
-                option1Name: parentItem.option1Name || "Title",
-                images: [],
-                lastUpdated: timestampMs,
-              },
-            });
-            createdHandles.add(storeHandle);
-          }
-        }
+        const parentJan = csvHandleToJan.get(item.handle || "");
+        ensureListingUpdate(
+          storeHandle,
+          (parentJan ? janToRow.get(parentJan) : null) || item,
+        );
 
         if (handleToListing[storeHandle] || createdHandles.has(storeHandle)) {
-          const targetImage = sanitizedListingImage;
-          if (targetImage) {
-            listingUpdates.push({
-              type: "add_image",
-              handle: storeHandle,
-              image: {
-                id: targetImage,
-                url: targetImage,
-                position: item.imagePosition || 0,
-                altText: item.imageAltText || "",
-              },
-            });
-            indices.push(index);
-          }
+          queueListingImageUpdate(storeHandle, item, sanitizedListingImage);
+          if (sanitizedListingImage) indices.push(index);
         }
       }
     }

--- a/src/lib/shopify-listing-projection.ts
+++ b/src/lib/shopify-listing-projection.ts
@@ -79,6 +79,15 @@ function trimString(value: unknown): string {
   return String(value || "").trim();
 }
 
+export function isListingSyncDisabled(
+  listing: { status?: unknown } | null | undefined,
+): boolean {
+  const normalized = trimString(listing?.status)
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_");
+  return normalized === "no_sync" || normalized === "nosync";
+}
+
 function finiteNumber(value: unknown): number {
   const parsed = Number(value || 0);
   return Number.isFinite(parsed) ? parsed : 0;
@@ -161,6 +170,7 @@ export function buildAdminShopifyListingProjection(params: {
   const handle = trimString(params.handle);
   const listing = params.listing;
   if (!handle || !listing) return null;
+  if (isListingSyncDisabled(listing)) return null;
 
   const rawVariants = (Array.isArray(params.items) ? params.items : [])
     .map((item): ShopifyListingProjectionVariant | null => {

--- a/src/routes/listing-detail/+page.svelte
+++ b/src/routes/listing-detail/+page.svelte
@@ -5,6 +5,7 @@
   import { store } from "$lib/store";
   import {
     update_listing,
+    rename_listing_handle,
     add_listing_image,
     remove_listing_image,
     type ListingImage,
@@ -36,7 +37,7 @@
   import { broadcast } from "$lib/redux-firestore";
   import { firestore } from "$lib/firebase";
   import { user } from "$lib/user-store";
-  import { generateHandle } from "$lib/handle-utils";
+  import { canonicalizeHandle, generateHandle } from "$lib/handle-utils";
   import {
     ensureFolderStructure,
     uploadImageToDrive,
@@ -87,6 +88,9 @@
   let searchTerm = "";
   let matchingHandles: string[] = [];
   let fileInput: HTMLInputElement;
+  let handleEditValue = "";
+  let isEditingHandle = false;
+  let handleEditError = "";
 
   onMount(() => {
     // Safety: Force reset stuck AI flags on load to prevent deadlocks
@@ -292,6 +296,11 @@
       console.warn("User not authenticated, falling back to local dispatch");
       store.dispatch(action);
     }
+  }
+
+  $: if (isLiveMode && handle && !isEditingHandle) {
+    handleEditValue = handle;
+    handleEditError = "";
   }
 
   // Sync Step Index if in Batch
@@ -750,6 +759,42 @@
         update_listing({ handle, changes: { productCategory: e.detail } }),
       );
     }
+  }
+
+  function saveListingHandle() {
+    const uid = $user.uid;
+    if (!uid || !handle) return;
+
+    const nextHandle = canonicalizeHandle(handleEditValue, "");
+    if (!nextHandle) {
+      handleEditError = "Enter a handle.";
+      return;
+    }
+    if (nextHandle === handle) {
+      handleEditValue = handle;
+      handleEditError = "";
+      isEditingHandle = false;
+      return;
+    }
+    if ($store.listings.handleToListing[nextHandle]) {
+      handleEditError = "Another local listing already uses this handle.";
+      return;
+    }
+
+    handleEditError = "";
+    isEditingHandle = false;
+    broadcast(
+      firestore,
+      uid,
+      rename_listing_handle({ from: handle, to: nextHandle }),
+    );
+    goto(`/listing-detail?mode=live&handle=${encodeURIComponent(nextHandle)}`);
+  }
+
+  function cancelListingHandleEdit() {
+    handleEditValue = handle || "";
+    handleEditError = "";
+    isEditingHandle = false;
   }
 
   function handleUpdatePrice(e: CustomEvent<number>) {
@@ -2078,6 +2123,37 @@
           {/each}
         </div>
       {/if}
+      {#if handle && listingData}
+        <div class="handle-edit-row">
+          <label class="handle-edit-label" for="listing-handle-input">
+            Handle
+          </label>
+          <input
+            id="listing-handle-input"
+            class="handle-edit-input"
+            type="text"
+            bind:value={handleEditValue}
+            on:focus={() => (isEditingHandle = true)}
+            on:keydown={(e) => {
+              if (e.key === "Enter") saveListingHandle();
+              if (e.key === "Escape") cancelListingHandleEdit();
+            }}
+          />
+          <button
+            class="handle-edit-btn"
+            disabled={!handleEditValue.trim() || handleEditValue === handle}
+            on:click={saveListingHandle}>Save Handle</button
+          >
+          {#if isEditingHandle && handleEditValue !== handle}
+            <button class="handle-cancel-btn" on:click={cancelListingHandleEdit}
+              >Cancel</button
+            >
+          {/if}
+          {#if handleEditError}
+            <span class="handle-edit-error">{handleEditError}</span>
+          {/if}
+        </div>
+      {/if}
     </div>
   {:else}
     <div class="search-header">
@@ -2475,6 +2551,56 @@
   }
   .back-btn:hover {
     background: #e5e7eb;
+  }
+  .handle-edit-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    max-width: 960px;
+  }
+  .handle-edit-label {
+    font-size: 0.85rem;
+    font-weight: 700;
+    color: #4b5563;
+  }
+  .handle-edit-input {
+    flex: 1 1 420px;
+    min-width: 260px;
+    border: 1px solid #d1d5db;
+    border-radius: 4px;
+    padding: 0.45rem 0.65rem;
+    font-family:
+      ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+      "Courier New", monospace;
+    font-size: 0.9rem;
+  }
+  .handle-edit-input:focus {
+    outline: none;
+    border-color: #3b82f6;
+    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.18);
+  }
+  .handle-edit-btn,
+  .handle-cancel-btn {
+    border: 1px solid #d1d5db;
+    border-radius: 4px;
+    padding: 0.45rem 0.75rem;
+    background: white;
+    color: #374151;
+    cursor: pointer;
+  }
+  .handle-edit-btn:hover:not(:disabled),
+  .handle-cancel-btn:hover {
+    border-color: #6b7280;
+  }
+  .handle-edit-btn:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+  .handle-edit-error {
+    color: #b91c1c;
+    font-size: 0.85rem;
+    font-weight: 600;
   }
 
   .ai-controls-toolbar {

--- a/src/routes/listing-detail/+page.svelte
+++ b/src/routes/listing-detail/+page.svelte
@@ -57,6 +57,7 @@
   import {
     buildAdminShopifyListingProjection,
     buildShopifySyncRequestEvent,
+    isListingSyncDisabled,
   } from "$lib/shopify-listing-projection";
   import { SHOPIFY_REQUEST_COLLECTION } from "$lib/sync-events";
 
@@ -91,6 +92,11 @@
   let handleEditValue = "";
   let isEditingHandle = false;
   let handleEditError = "";
+  const listingStatusOptions = [
+    { value: "active", label: "Active" },
+    { value: "draft", label: "Draft" },
+    { value: "no_sync", label: "No Sync" },
+  ] as const;
 
   onMount(() => {
     // Safety: Force reset stuck AI flags on load to prevent deadlocks
@@ -146,6 +152,7 @@
     bodyHtml: string;
     productCategory?: string;
     option1Name?: string;
+    status?: "active" | "archived" | "draft" | "no_sync";
     titlePrompt?: string;
     descriptionPrompt?: string;
   } | null = null;
@@ -597,6 +604,11 @@
       syncMessage = "Sign in to queue a Shopify sync request.";
       return;
     }
+    if (isListingSyncDisabled(listingData)) {
+      syncMessage = "This listing is set to No Sync.";
+      syncMessageLevel = "error";
+      return;
+    }
 
     const projection = buildAdminShopifyListingProjection({
       handle,
@@ -795,6 +807,15 @@
     handleEditValue = handle || "";
     handleEditError = "";
     isEditingHandle = false;
+  }
+
+  function handleListingStatusChange(e: Event) {
+    const uid = $user.uid;
+    if (!uid || !handle) return;
+    const target = e.currentTarget as HTMLSelectElement;
+    const status = target.value as "active" | "draft" | "no_sync";
+    if (status === listingData?.status) return;
+    broadcast(firestore, uid, update_listing({ handle, changes: { status } }));
   }
 
   function handleUpdatePrice(e: CustomEvent<number>) {
@@ -2152,6 +2173,19 @@
           {#if handleEditError}
             <span class="handle-edit-error">{handleEditError}</span>
           {/if}
+          <label class="handle-edit-label" for="listing-status-select">
+            Status
+          </label>
+          <select
+            id="listing-status-select"
+            class="listing-status-select"
+            value={listingData.status || "active"}
+            on:change={handleListingStatusChange}
+          >
+            {#each listingStatusOptions as option}
+              <option value={option.value}>{option.label}</option>
+            {/each}
+          </select>
         </div>
       {/if}
     </div>
@@ -2267,11 +2301,17 @@
           {#if mode !== "create" && handle}
             <button
               class="ai-btn"
-              disabled={isQueueingSync}
+              disabled={isQueueingSync || isListingSyncDisabled(listingData)}
               on:click={queueShopifyListingSync}
-              title="Queue this listing for Shopify API sync"
+              title={isListingSyncDisabled(listingData)
+                ? "Change status from No Sync to sync this listing"
+                : "Queue this listing for Shopify API sync"}
             >
-              {isQueueingSync ? "Queueing..." : "Sync This Listing"}
+              {#if isListingSyncDisabled(listingData)}
+                Sync Disabled
+              {:else}
+                {isQueueingSync ? "Queueing..." : "Sync This Listing"}
+              {/if}
             </button>
           {/if}
         </div>
@@ -2576,6 +2616,19 @@
     font-size: 0.9rem;
   }
   .handle-edit-input:focus {
+    outline: none;
+    border-color: #3b82f6;
+    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.18);
+  }
+  .listing-status-select {
+    border: 1px solid #d1d5db;
+    border-radius: 4px;
+    padding: 0.45rem 0.65rem;
+    background: white;
+    color: #374151;
+    font-size: 0.9rem;
+  }
+  .listing-status-select:focus {
     outline: none;
     border-color: #3b82f6;
     box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.18);

--- a/src/routes/shopify-listings/+page.svelte
+++ b/src/routes/shopify-listings/+page.svelte
@@ -12,6 +12,7 @@
     buildAdminShopifyListingProjectionFromState,
     buildComparableAdminShopifySyncProjection,
     buildShopifySyncRequestEvent,
+    isListingSyncDisabled,
   } from "$lib/shopify-listing-projection";
   import ShopifyListingIssueDetail from "$lib/components/ShopifyListingIssueDetail.svelte";
   import type { ShopifyCatalogListing } from "$lib/shopify-catalog-slice";
@@ -56,11 +57,13 @@
     diffDetails: DetailedShopifyDiffResult | null;
     issueKeys: IssueKey[];
     primaryIssue: IssueKey;
+    syncDisabled: boolean;
   }
   type TableStatus =
     | "would_create"
     | "shopify_only"
     | "would_update"
+    | "no_sync"
     | "no_edit";
 
   const SKEW_MS = 3 * 60_000;
@@ -335,7 +338,11 @@
     status: RowStatus,
     drift: DriftStatus,
     diffDetails: DetailedShopifyDiffResult | null,
+    syncDisabled: boolean,
   ): IssueKey[] {
+    if (syncDisabled) {
+      return status === "both" ? ["presence"] : ["synced"];
+    }
     if (status !== "both") return ["presence"];
     if (!diffDetails || diffDetails.matches) {
       return drift === "in_sync" || drift === "unknown"
@@ -428,6 +435,9 @@
   }
 
   function issueSummary(row: ListingPresenceRow): string {
+    if (row.syncDisabled && row.inShopify)
+      return "No Sync listing exists on Shopify";
+    if (row.syncDisabled) return "Local listing is set to No Sync";
     if (row.status === "admin_only") return "Sync would create on Shopify";
     if (row.status === "shopify_only") return "Only in Shopify";
     return row.issueKeys.map((issue) => issueChipText(row, issue)).join(", ");
@@ -463,6 +473,7 @@
         const inShopify = shopifyByKey.has(key);
         const handle = adminByKey.get(key) || shopifyByKey.get(key) || key;
         const listing = inAdmin ? handleToListing[handle] : null;
+        const syncDisabled = isListingSyncDisabled(listing);
         const remoteHandle = shopifyByKey.get(key) || "";
         const remoteListing: ShopifyCatalogListing | null = remoteHandle
           ? shopifyHandleToListing[remoteHandle]
@@ -503,7 +514,12 @@
           }
         }
 
-        const issueKeys = classifyIssueKeys(status, drift, diffDetails);
+        const issueKeys = classifyIssueKeys(
+          status,
+          drift,
+          diffDetails,
+          syncDisabled,
+        );
 
         return {
           handle,
@@ -519,6 +535,7 @@
           diffDetails,
           issueKeys,
           primaryIssue: issueKeys[0],
+          syncDisabled,
         };
       })
       .sort((a, b) => {
@@ -536,6 +553,7 @@
   }
 
   function getTableStatus(row: ListingPresenceRow): TableStatus {
+    if (row.syncDisabled) return "no_sync";
     if (row.status === "admin_only") return "would_create";
     if (row.status === "shopify_only") return "shopify_only";
     if (row.deepDiff) return "would_update";
@@ -546,6 +564,7 @@
     if (status === "would_create") return "would create";
     if (status === "would_update") return "would update";
     if (status === "no_edit") return "no edit";
+    if (status === "no_sync") return "no sync";
     return "only in Shopify";
   }
 
@@ -606,7 +625,7 @@
   function syncableRows(
     sectionRows: ListingPresenceRow[],
   ): ListingPresenceRow[] {
-    return sectionRows.filter((row) => row.inAdmin);
+    return sectionRows.filter((row) => row.inAdmin && !row.syncDisabled);
   }
 
   async function syncListingsForSection(
@@ -1393,6 +1412,11 @@
   .badge.no_edit {
     background: #dcfce7;
     color: #166534;
+  }
+
+  .badge.no_sync {
+    background: #e5e7eb;
+    color: #374151;
   }
 
   .diff-link {

--- a/tests/unit/fix-jancode.test.ts
+++ b/tests/unit/fix-jancode.test.ts
@@ -11,6 +11,7 @@ import { categorize_photo } from "$lib/photos-slice";
 import { add_proposals_internal } from "$lib/listing-creation-slice";
 import { resolve_conflict as resolveOrderConflict } from "$lib/order-import-slice";
 import { resolve_conflict as resolveShopifyConflict } from "$lib/shopify-import-slice";
+import { create_listing } from "$lib/listings-slice";
 
 // Every replayed action carries a timestamp in production; these
 // fixtures omit it, so stamp a fixed one (deriveCreationTimestampMs
@@ -49,6 +50,26 @@ describe("fix_jancode", () => {
           shipped: 0,
           creationDate: "Jan 1, 2026",
           timestamp: 0,
+        },
+      }) as any,
+    );
+
+    state = rootReducer(
+      state,
+      create_listing({
+        listing: {
+          handle: "tea-pack",
+          title: "Tea Pack",
+          bodyHtml: "<p>desc</p>",
+          productCategory: "Food",
+          productType: "",
+          vendor: "Vendor",
+          tags: [],
+          status: "draft",
+          option1Name: "Color",
+          variantOptionsByItemId: {},
+          images: [],
+          lastUpdated: 0,
         },
       }) as any,
     );

--- a/tests/unit/listing-handle-sync.test.ts
+++ b/tests/unit/listing-handle-sync.test.ts
@@ -197,6 +197,67 @@ describe("inventory handle updates sync to listings", () => {
     });
   });
 
+  it("clears stale listing option labels when the only linked JAN is set to Default", () => {
+    const handle =
+      "amifa-masterpiece-collection-b6-clear-folder-3-4542804147667";
+    const janCode = "4542804147667";
+    const item: Item = {
+      janCode,
+      subtype: "",
+      description: "Amifa Masterpiece Collection B6 Clear Folder (3)",
+      hsCode: "39261000",
+      image: "http://example.com/folder.jpg",
+      qty: 12,
+      pieces: 1,
+      shipped: 0,
+      creationDate: "2026-03-10",
+      timestamp: 0,
+      handle,
+    };
+
+    let state = rootReducer(undefined as any, { type: "@@INIT" });
+    state = rootReducer(
+      state,
+      create_listing({
+        listing: makeListing(handle, item.description, janCode),
+      }),
+    );
+    state = rootReducer(state, update_item({ id: janCode, item }));
+    state = {
+      ...state,
+      listings: {
+        ...state.listings,
+        handleToListing: {
+          ...state.listings.handleToListing,
+          [handle]: {
+            ...state.listings.handleToListing[handle],
+            variantOptionsByItemId: {
+              [`${janCode}Blue`]: "Blue",
+              [`${janCode}Cream`]: "Cream",
+              [janCode]: "Pink",
+            },
+          },
+        },
+      },
+    };
+
+    state = rootReducer(
+      state,
+      update_field({
+        id: janCode,
+        field: "subtype",
+        from: "",
+        to: "Default",
+      }),
+    );
+
+    expect(state.inventory.idToItem[janCode]).toBeDefined();
+    expect(state.listings.idToHandle[janCode]).toBe(handle);
+    expect(
+      state.listings.handleToListing[handle].variantOptionsByItemId,
+    ).toEqual({});
+  });
+
   it("updates a listing option label when it only reflected the old subtype", () => {
     const handle = "amifa-animal-flake-stickers-100-4542804141160";
     const item: Item = {

--- a/tests/unit/listing-handle-sync.test.ts
+++ b/tests/unit/listing-handle-sync.test.ts
@@ -35,6 +35,57 @@ const makeListing = (handle: string, title: string, janCode = "123"): Listing =>
   }) as Listing;
 
 describe("inventory handle updates sync to listings", () => {
+  it("creates stable synthetic photo ids when importing existing variants", () => {
+    const janCode = "4901234567890";
+    const id = `${janCode}Blue`;
+    const image =
+      "https://cdn.shopify.com//s/files/1/0914/2937/2286/files/imported.jpg?v=123";
+    const item: Item = {
+      janCode,
+      subtype: "Blue",
+      description: "Test Item",
+      hsCode: "49090000",
+      image,
+      qty: 1,
+      pieces: 1,
+      shipped: 0,
+      creationDate: "2024-01-01",
+      timestamp: 0,
+      handle: "existing-handle",
+    };
+    const importAction = {
+      type: "listingCreation/import_existing_variants",
+      payload: { janCode, handle: "existing-handle" },
+      timestamp: { _seconds: 1_710_000_000, _nanoseconds: 0 },
+    };
+
+    const buildState = () => {
+      let state = rootReducer(undefined as any, { type: "@@INIT" });
+      state = rootReducer(
+        state,
+        create_listing({
+          listing: {
+            ...makeListing("existing-handle", item.description, janCode),
+            variantOptionsByItemId: { [id]: "Blue" },
+          } as Listing,
+        }),
+      );
+      state = rootReducer(state, update_item({ id, item }));
+      return rootReducer(state, importAction);
+    };
+
+    const first = buildState();
+    const second = buildState();
+    const firstPhoto = first.photos.janCodeToPhotos[`${janCode}:Blue`][0];
+    const secondPhoto = second.photos.janCodeToPhotos[`${janCode}:Blue`][0];
+
+    expect(firstPhoto.id).toMatch(/^synthetic-/);
+    expect(firstPhoto.id).toBe(secondPhoto.id);
+    expect(firstPhoto.mediaMetadata.creationTime).toBe(
+      "2024-03-09T16:00:00.000Z",
+    );
+  });
+
   it("does not create a listing when handle changes to a missing explicit handle", () => {
     const item: Item = {
       janCode: "4901234567890",

--- a/tests/unit/listing-handle-sync.test.ts
+++ b/tests/unit/listing-handle-sync.test.ts
@@ -211,6 +211,65 @@ describe("inventory handle updates sync to listings", () => {
     });
   });
 
+  it("updates a stale target-key listing option when it still reflected the old subtype", () => {
+    const handle = "furukawa-mini-washi-paper-letter-set";
+    const item: Item = {
+      janCode: "4952270302420",
+      subtype: "Cat/Flower",
+      description: "Furukawa Mini Washi Paper Letter Set",
+      hsCode: "48173000",
+      image: "http://example.com/cat-flower.jpg",
+      qty: 10,
+      pieces: 1,
+      shipped: 0,
+      creationDate: "2026-03-17",
+      timestamp: 0,
+      handle,
+    };
+    const oldId = `${item.janCode}${item.subtype}`;
+    const newId = `${item.janCode}Cat`;
+
+    let state = rootReducer(undefined as any, { type: "@@INIT" });
+    state = rootReducer(state, update_item({ id: oldId, item }));
+    state = {
+      ...state,
+      listings: {
+        ...state.listings,
+        idToHandle: {
+          ...state.listings.idToHandle,
+          [newId]: handle,
+        },
+        handleToListing: {
+          ...state.listings.handleToListing,
+          [handle]: {
+            ...state.listings.handleToListing[handle],
+            variantOptionsByItemId: {
+              [newId]: "Cat/Flower",
+            },
+          },
+        },
+      },
+    };
+
+    state = rootReducer(
+      state,
+      update_field({
+        id: oldId,
+        field: "subtype",
+        from: "Cat/Flower",
+        to: "Cat",
+      }),
+    );
+
+    expect(state.inventory.idToItem[oldId]).toBeUndefined();
+    expect(state.inventory.idToItem[newId].subtype).toBe("Cat");
+    expect(
+      state.listings.handleToListing[handle].variantOptionsByItemId,
+    ).toEqual({
+      [newId]: "Cat",
+    });
+  });
+
   it("does not overwrite the target listing handle when replacing one subtype with another existing subtype", () => {
     const janCode = "4542804155181";
     const sourceHandle = "stale-a5-zipper-case-4542804155181";

--- a/tests/unit/listing-handle-sync.test.ts
+++ b/tests/unit/listing-handle-sync.test.ts
@@ -16,9 +16,26 @@ import {
   update_item,
   type Item,
 } from "$lib/inventory";
+import { create_listing, type Listing } from "$lib/listings-slice";
+
+const makeListing = (handle: string, title: string, janCode = "123"): Listing =>
+  ({
+    handle,
+    title,
+    bodyHtml: "",
+    productCategory: "",
+    productType: "",
+    vendor: "SPNSS Ltd.",
+    tags: [],
+    status: "active",
+    option1Name: "Subtype",
+    images: [],
+    lastUpdated: 0,
+    janCode,
+  }) as Listing;
 
 describe("inventory handle updates sync to listings", () => {
-  it("keeps listings.idToHandle and handleToListing aligned when handle changes via update_field", () => {
+  it("does not create a listing when handle changes to a missing explicit handle", () => {
     const item: Item = {
       janCode: "4901234567890",
       subtype: "Red",
@@ -35,6 +52,12 @@ describe("inventory handle updates sync to listings", () => {
     const id = `${item.janCode}${item.subtype}`;
 
     let state = rootReducer(undefined as any, { type: "@@INIT" });
+    state = rootReducer(
+      state,
+      create_listing({
+        listing: makeListing("old-handle", item.description, item.janCode),
+      }),
+    );
     state = rootReducer(state, update_item({ id, item }));
 
     expect(state.listings.idToHandle[id]).toBe("old-handle");
@@ -51,9 +74,9 @@ describe("inventory handle updates sync to listings", () => {
     );
 
     expect(state.inventory.idToItem[id].handle).toBe("new-handle");
-    expect(state.listings.idToHandle[id]).toBe("new-handle");
-    expect(state.listings.handleToListing["new-handle"]).toBeDefined();
-    expect(state.listings.handleToListing["old-handle"]).toBeUndefined();
+    expect(state.listings.idToHandle[id]).toBeUndefined();
+    expect(state.listings.handleToListing["new-handle"]).toBeUndefined();
+    expect(state.listings.handleToListing["old-handle"]).toBeDefined();
   });
 
   it("merges into existing listing when handle changes to an existing handle", () => {
@@ -87,6 +110,18 @@ describe("inventory handle updates sync to listings", () => {
     const idB = `${itemB.janCode}${itemB.subtype}`;
 
     let state = rootReducer(undefined as any, { type: "@@INIT" });
+    state = rootReducer(
+      state,
+      create_listing({
+        listing: makeListing("handle-a", itemA.description, itemA.janCode),
+      }),
+    );
+    state = rootReducer(
+      state,
+      create_listing({
+        listing: makeListing("handle-b", itemB.description, itemB.janCode),
+      }),
+    );
     state = rootReducer(state, update_item({ id: idA, item: itemA }));
     state = rootReducer(state, update_item({ id: idB, item: itemB }));
 
@@ -106,7 +141,7 @@ describe("inventory handle updates sync to listings", () => {
     expect(state.listings.idToHandle[idA]).toBe("handle-b");
     expect(state.listings.idToHandle[idB]).toBe("handle-b");
     expect(state.listings.handleToListing["handle-b"]).toBeDefined();
-    expect(state.listings.handleToListing["handle-a"]).toBeUndefined();
+    expect(state.listings.handleToListing["handle-a"]).toBeDefined();
   });
 
   it("preserves a listing option label when a listed subtyped item normalizes to bare JAN", () => {
@@ -127,6 +162,12 @@ describe("inventory handle updates sync to listings", () => {
     const oldId = `${item.janCode}${item.subtype}`;
 
     let state = rootReducer(undefined as any, { type: "@@INIT" });
+    state = rootReducer(
+      state,
+      create_listing({
+        listing: makeListing(handle, item.description, item.janCode),
+      }),
+    );
     state = rootReducer(state, update_item({ id: oldId, item }));
 
     expect(state.listings.idToHandle[oldId]).toBe(handle);
@@ -174,6 +215,12 @@ describe("inventory handle updates sync to listings", () => {
     const oldId = `${item.janCode}${item.subtype}`;
 
     let state = rootReducer(undefined as any, { type: "@@INIT" });
+    state = rootReducer(
+      state,
+      create_listing({
+        listing: makeListing(handle, item.description, item.janCode),
+      }),
+    );
     state = rootReducer(state, update_item({ id: oldId, item }));
     state = {
       ...state,
@@ -230,6 +277,12 @@ describe("inventory handle updates sync to listings", () => {
     const newId = `${item.janCode}Cat`;
 
     let state = rootReducer(undefined as any, { type: "@@INIT" });
+    state = rootReducer(
+      state,
+      create_listing({
+        listing: makeListing(handle, item.description, item.janCode),
+      }),
+    );
     state = rootReducer(state, update_item({ id: oldId, item }));
     state = {
       ...state,
@@ -299,6 +352,18 @@ describe("inventory handle updates sync to listings", () => {
     };
 
     let state = rootReducer(undefined as any, { type: "@@INIT" });
+    state = rootReducer(
+      state,
+      create_listing({
+        listing: makeListing(sourceHandle, sourceItem.description, janCode),
+      }),
+    );
+    state = rootReducer(
+      state,
+      create_listing({
+        listing: makeListing(targetHandle, targetItem.description, janCode),
+      }),
+    );
     state = rootReducer(state, update_item({ id: sourceId, item: sourceItem }));
     state = rootReducer(state, update_item({ id: targetId, item: targetItem }));
     state = {

--- a/tests/unit/listing-handle-update.test.ts
+++ b/tests/unit/listing-handle-update.test.ts
@@ -11,9 +11,26 @@ const rootReducer = (s: any, a: any) =>
       : a,
   );
 import { update_item, update_field, type Item } from "$lib/inventory";
+import { create_listing, type Listing } from "$lib/listings-slice";
+
+const makeListing = (handle: string, title: string, janCode = "123"): Listing =>
+  ({
+    handle,
+    title,
+    bodyHtml: "",
+    productCategory: "",
+    productType: "",
+    vendor: "SPNSS Ltd.",
+    tags: [],
+    status: "active",
+    option1Name: "Subtype",
+    images: [],
+    lastUpdated: 0,
+    janCode,
+  }) as Listing;
 
 describe("listing handle update logic", () => {
-  it("keeps an explicit handle stable when the item description changes", () => {
+  it("keeps an existing linked handle stable when the item description changes", () => {
     const baseItem: Item = {
       janCode: "4542804116380",
       subtype: "Blue",
@@ -32,6 +49,16 @@ describe("listing handle update logic", () => {
     const idPurple = "4542804116380Purple";
 
     let state = rootReducer(undefined as any, { type: "@@INIT" });
+    state = rootReducer(
+      state,
+      create_listing({
+        listing: makeListing(
+          baseItem.handle || "",
+          baseItem.description,
+          baseItem.janCode,
+        ),
+      }),
+    );
     state = rootReducer(state, update_item({ id: idBlue, item: baseItem }));
     state = rootReducer(
       state,
@@ -85,6 +112,12 @@ describe("listing handle update logic", () => {
     const idB = "123B";
 
     let state = rootReducer(undefined as any, { type: "@@INIT" });
+    state = rootReducer(
+      state,
+      create_listing({
+        listing: makeListing("H1", itemA.description, itemA.janCode),
+      }),
+    );
     state = rootReducer(state, update_item({ id: idA, item: itemA }));
     state = rootReducer(state, update_item({ id: idB, item: itemB }));
 
@@ -93,7 +126,7 @@ describe("listing handle update logic", () => {
     expect(state.listings.idToHandle[idA]).toBe("H1");
     expect(state.listings.idToHandle[idB]).toBe("H1");
 
-    // Move A to H2
+    // Set A to a missing handle. This unlinks A from H1 but does not create H2.
     state = rootReducer(
       state,
       update_field({ id: idA, field: "handle", from: "H1", to: "H2" }),
@@ -101,16 +134,125 @@ describe("listing handle update logic", () => {
 
     // H1 should STILL exist because B is there
     expect(state.listings.handleToListing["H1"]).toBeDefined();
-    expect(state.listings.handleToListing["H2"]).toBeDefined();
+    expect(state.listings.idToHandle[idA]).toBeUndefined();
+    expect(state.listings.handleToListing["H2"]).toBeUndefined();
 
-    // Move B to H2
+    // Set B to the same missing handle. This unlinks B, but handle edits do
+    // not delete listing rows.
     state = rootReducer(
       state,
       update_field({ id: idB, field: "handle", from: "H1", to: "H2" }),
     );
 
-    // H1 should be gone now
-    expect(state.listings.handleToListing["H1"]).toBeUndefined();
-    expect(state.listings.handleToListing["H2"]).toBeDefined();
+    expect(state.listings.handleToListing["H1"]).toBeDefined();
+    expect(state.listings.idToHandle[idA]).toBeUndefined();
+    expect(state.listings.idToHandle[idB]).toBeUndefined();
+    expect(state.listings.handleToListing["H2"]).toBeUndefined();
+  });
+
+  it("does not create a generated-default listing when clearing a shared handle", () => {
+    const itemA: Item = {
+      janCode: "123",
+      subtype: "A",
+      description: "Default Product",
+      handle: "shared-handle",
+      qty: 1,
+      price: 100,
+      shipped: 0,
+      pieces: 1,
+      creationDate: "",
+      timestamp: 0,
+      hsCode: "",
+      image: "",
+    };
+    const itemB: Item = { ...itemA, subtype: "B" };
+    const idA = "123A";
+    const idB = "123B";
+    const generatedHandle = "default-product-123";
+
+    let state = rootReducer(undefined as any, { type: "@@INIT" });
+    state = rootReducer(
+      state,
+      create_listing({
+        listing: makeListing("shared-handle", itemA.description, itemA.janCode),
+      }),
+    );
+    state = rootReducer(state, update_item({ id: idA, item: itemA }));
+    state = rootReducer(state, update_item({ id: idB, item: itemB }));
+
+    expect(state.listings.idToHandle[idA]).toBe("shared-handle");
+    expect(state.listings.idToHandle[idB]).toBe("shared-handle");
+
+    state = rootReducer(
+      state,
+      update_field({
+        id: idA,
+        field: "handle",
+        from: "shared-handle",
+        to: "",
+      }),
+    );
+
+    expect(state.inventory.idToItem[idA].handle).toBe("");
+    expect(state.listings.idToHandle[idA]).toBeUndefined();
+    expect(state.listings.idToHandle[idB]).toBe("shared-handle");
+    expect(state.listings.handleToListing["shared-handle"]).toBeDefined();
+    expect(state.listings.handleToListing[generatedHandle]).toBeUndefined();
+  });
+
+  it("does not link to a generated-default listing when clearing a handle", () => {
+    const item: Item = {
+      janCode: "123",
+      subtype: "A",
+      description: "Default Product",
+      handle: "old-handle",
+      qty: 1,
+      price: 100,
+      shipped: 0,
+      pieces: 1,
+      creationDate: "",
+      timestamp: 0,
+      hsCode: "",
+      image: "",
+    };
+    const id = "123A";
+    const generatedHandle = "default-product-123";
+
+    let state = rootReducer(undefined as any, { type: "@@INIT" });
+    state = rootReducer(
+      state,
+      create_listing({
+        listing: makeListing("old-handle", item.description, item.janCode),
+      }),
+    );
+    state = rootReducer(state, update_item({ id, item }));
+    state = {
+      ...state,
+      listings: {
+        ...state.listings,
+        handleToListing: {
+          ...state.listings.handleToListing,
+          [generatedHandle]: {
+            ...state.listings.handleToListing["old-handle"],
+            handle: generatedHandle,
+          },
+        },
+      },
+    };
+
+    state = rootReducer(
+      state,
+      update_field({
+        id,
+        field: "handle",
+        from: "old-handle",
+        to: "",
+      }),
+    );
+
+    expect(state.inventory.idToItem[id].handle).toBe("");
+    expect(state.listings.idToHandle[id]).toBeUndefined();
+    expect(state.listings.handleToListing[generatedHandle]).toBeDefined();
+    expect(state.listings.handleToListing["old-handle"]).toBeDefined();
   });
 });

--- a/tests/unit/listing-handle-update.test.ts
+++ b/tests/unit/listing-handle-update.test.ts
@@ -11,7 +11,11 @@ const rootReducer = (s: any, a: any) =>
       : a,
   );
 import { update_item, update_field, type Item } from "$lib/inventory";
-import { create_listing, type Listing } from "$lib/listings-slice";
+import {
+  create_listing,
+  rename_listing_handle,
+  type Listing,
+} from "$lib/listings-slice";
 
 const makeListing = (handle: string, title: string, janCode = "123"): Listing =>
   ({
@@ -254,5 +258,116 @@ describe("listing handle update logic", () => {
     expect(state.listings.idToHandle[id]).toBeUndefined();
     expect(state.listings.handleToListing[generatedHandle]).toBeDefined();
     expect(state.listings.handleToListing["old-handle"]).toBeDefined();
+  });
+
+  it("renames a listing handle and updates all linked inventory references", () => {
+    const itemA: Item = {
+      janCode: "4969757171813",
+      subtype: "Pomeranian",
+      description: "Love Fur Sticky Notes",
+      handle: "old-handle",
+      qty: 12,
+      price: 4,
+      shipped: 1,
+      pieces: 1,
+      creationDate: "",
+      timestamp: 0,
+      hsCode: "",
+      image: "",
+    };
+    const itemB: Item = {
+      ...itemA,
+      subtype: "Poodle",
+      shipped: 2,
+    };
+    const idA = "4969757171813Pomeranian";
+    const idB = "4969757171813Poodle";
+
+    let state = rootReducer(undefined as any, { type: "@@INIT" });
+    state = rootReducer(
+      state,
+      create_listing({
+        listing: {
+          ...makeListing("old-handle", itemA.description, itemA.janCode),
+          variantOptionsByItemId: {
+            [idA]: "Pomeranian",
+            [idB]: "Poodle",
+          },
+        },
+      }),
+    );
+    state = rootReducer(state, update_item({ id: idA, item: itemA }));
+    state = rootReducer(state, update_item({ id: idB, item: itemB }));
+
+    state = rootReducer(
+      state,
+      rename_listing_handle({ from: "old-handle", to: "new-handle" }),
+    );
+
+    expect(state.listings.handleToListing["old-handle"]).toBeUndefined();
+    expect(state.listings.handleToListing["new-handle"]).toMatchObject({
+      handle: "new-handle",
+      title: itemA.description,
+      variantOptionsByItemId: {
+        [idA]: "Pomeranian",
+        [idB]: "Poodle",
+      },
+    });
+    expect(state.listings.idToHandle[idA]).toBe("new-handle");
+    expect(state.listings.idToHandle[idB]).toBe("new-handle");
+    expect(state.inventory.idToItem[idA].handle).toBe("new-handle");
+    expect(state.inventory.idToItem[idB].handle).toBe("new-handle");
+    expect(
+      state.inventory.idToHistory[idA].some((entry: any) =>
+        String(entry.desc).includes(
+          "handle changed from old-handle to new-handle",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not rename or relink when the target handle already exists", () => {
+    const item: Item = {
+      janCode: "123",
+      subtype: "A",
+      description: "Item A",
+      handle: "old-handle",
+      qty: 1,
+      price: 100,
+      shipped: 0,
+      pieces: 1,
+      creationDate: "",
+      timestamp: 0,
+      hsCode: "",
+      image: "",
+    };
+    const id = "123A";
+
+    let state = rootReducer(undefined as any, { type: "@@INIT" });
+    state = rootReducer(
+      state,
+      create_listing({
+        listing: makeListing("old-handle", item.description, item.janCode),
+      }),
+    );
+    state = rootReducer(
+      state,
+      create_listing({
+        listing: makeListing("new-handle", "Existing listing", item.janCode),
+      }),
+    );
+    state = rootReducer(state, update_item({ id, item }));
+
+    state = rootReducer(
+      state,
+      rename_listing_handle({ from: "old-handle", to: "new-handle" }),
+    );
+
+    expect(state.listings.handleToListing["old-handle"]).toBeDefined();
+    expect(state.listings.handleToListing["new-handle"].title).toBe(
+      "Existing listing",
+    );
+    expect(state.listings.idToHandle[id]).toBe("old-handle");
+    expect(state.inventory.idToItem[id].handle).toBe("old-handle");
   });
 });

--- a/tests/unit/replay-4542804151626-subtype.test.ts
+++ b/tests/unit/replay-4542804151626-subtype.test.ts
@@ -21,7 +21,7 @@ function loadReplayActions() {
 }
 
 describe("Replay 4542804151626 subtype creation", () => {
-  it("ends with Blue and Green subtype items for the JAN", () => {
+  it("ends with Blue and Green subtype items attached to the listing", () => {
     const actions = loadReplayActions();
     let state = rootReducer(undefined, { type: "@@INIT" });
 
@@ -48,5 +48,10 @@ describe("Replay 4542804151626 subtype creation", () => {
       `Expected Green subtype at ${greenKey}. Existing keys for JAN: ${subtypeKeysForJan.join(", ") || "(none)"}`,
     ).toBeDefined();
     expect(items[greenKey].subtype).toBe("Green");
+
+    const handle = "amifa-arctic-animals-sparkle-stickers-20-4542804151626";
+    expect(state.listings.idToHandle[blueKey]).toBe(handle);
+    expect(state.listings.idToHandle[greenKey]).toBe(handle);
+    expect(state.listings.idToHandle[JAN]).toBeUndefined();
   });
 });

--- a/tests/unit/shopify-listing-projection.test.ts
+++ b/tests/unit/shopify-listing-projection.test.ts
@@ -81,6 +81,28 @@ describe("Shopify listing projection", () => {
     });
   });
 
+  it("does not build a Shopify projection for No Sync listings", () => {
+    const projection = buildAdminShopifyListingProjection({
+      handle: "no-sync-listing",
+      listing: {
+        handle: "no-sync-listing",
+        title: "No Sync Listing",
+        status: "no_sync",
+      },
+      items: [
+        {
+          id: "4542804105827Red",
+          janCode: "4542804105827",
+          subtype: "Red",
+          qty: 4,
+          shipped: 1,
+        } as any,
+      ],
+    });
+
+    expect(projection).toBeNull();
+  });
+
   it("projects the post-sync Shopify product image shape", () => {
     const projection = buildAdminShopifyListingProjection({
       handle: "image-listing",


### PR DESCRIPTION
## What changed

- Added a shared inventory mutation key resolver for subtype mutations.
- Made `update_field` / `update_fields` subtype handling resolve labeled default SKUs back to the current inventory item before mutating.
- Made the root reducer use the same resolution before migrating listing `idToHandle` entries and photo groups.
- Strengthened the `4542804151626` replay regression test so both Blue and Green must remain attached to the listing.

## Why

A production replay showed `4542804151626Default -> Green` was interpreted by the inventory reducer as a rename of the bare JAN, but the root reducer used the raw action id when migrating listing/photo state. That left `4542804151626Green` missing from the listing even though the inventory item existed.

## Validation

- `bun test tests/unit/replay-4542804151626-subtype.test.ts`
- `bunx svelte-check --tsconfig ./tsconfig.json`
- Pre-commit hook: formatting, reducer `Date.now` check, `svelte-check`, full Vitest suite with coverage: 75 files passed, 545 tests passed.
- Pre-push hook: live fixture doctor, live Vitest, live E2E, and non-live E2E all passed.
- Full blast-radius replay against `../production-backup-jun-26-trace-4542804151626`:
  - order value summary unchanged
  - inventory value report unchanged
  - recount found stock unchanged
  - weighted average cost changes: 0
  - total on-hand inventory value delta: 0
  - expected listing/key migrations for `4542804151626Green` and the same subtype-rename class in three Furukawa letter-set items

Blast-radius report: `.blastradius/runs/subtype-update-listing-key-4542804151626-pr-base/report.md`